### PR TITLE
Cache cloudinary image metadata in file system during development

### DIFF
--- a/.claude/specs/cloudinary-caching.md
+++ b/.claude/specs/cloudinary-caching.md
@@ -1,0 +1,117 @@
+# Cloudinary Rate Limiting Fix: Local Filesystem Cache
+
+## Problem
+
+During local development, Next.js 16 is making repeated Cloudinary API calls for the same images, hitting rate limits within 5-10 minutes of normal dev work. The `Image` component has `'use cache'` directive, but the underlying `fetchCloudinaryImageMetadata` function doesn't cache its responses.
+
+## Current Implementation
+
+- `ui/image.tsx`: Has `'use cache'` directive (line 24)
+- `lib/cloudinary/fetchCloudinaryImageMetadata.ts`: Makes API calls via `cloudinary.api.resource()` with no caching
+- Each page refresh triggers fresh API calls for all images
+
+## Solution: Filesystem Cache for Dev Mode
+
+Implement a filesystem cache that:
+1. Stores Cloudinary API responses in `.local-cache/cloudinary/` directory
+2. Keys cache files by public ID (e.g., `{publicId}.json`)
+3. Checks cache before making API calls
+4. Only enabled in development mode (check `process.env.NODE_ENV === 'development'`)
+5. Gracefully handles cache read/write errors (logs warning, continues with API call)
+
+## Implementation Plan
+
+### 1. Create Cache Utility (`lib/cache/filesystem.ts`)
+
+```typescript
+/**
+ * Simple filesystem cache for development mode.
+ * Stores JSON responses keyed by a cache key.
+ */
+export async function getCached<T>(key: string, dir: string = '.local-cache'): Promise<T | null>
+export async function setCached<T>(key: string, data: T, dir: string = '.local-cache'): Promise<void>
+```
+
+Features:
+- Sanitize cache keys (replace `/` with `_`, handle special chars)
+- Store in `.local-cache/{dir}/{key}.json`
+- Return `null` on cache miss or read errors
+- Log cache hits/misses for visibility
+- Only operate in development mode
+
+### 2. Update `fetchCloudinaryImageMetadata`
+
+Add caching layer:
+```typescript
+const cacheKey = publicId.replace(/\//g, '_')
+const cached = await getCached<CloudinaryImageMetadata>(cacheKey, 'cloudinary')
+if (cached) {
+  console.log(`✅ Cache hit for "${publicId}"`)
+  return cached
+}
+
+// ... existing API call ...
+
+// Cache the result before returning
+await setCached(cacheKey, metadata, 'cloudinary')
+```
+
+### 3. Update `.gitignore`
+
+Add `.local-cache/` to prevent committing cached responses.
+
+### 4. Add Cache Bust Mechanism (Optional)
+
+Consider adding a way to invalidate cache:
+- npm script: `"cache:clear": "rm -rf .local-cache"`
+- Or TTL-based invalidation (check file mtime)
+
+## Why This Approach?
+
+1. **Reliable in dev mode**: Filesystem cache survives hot reloads and Next.js dev server restarts
+2. **Simple**: No external dependencies, just Node.js `fs` module
+3. **Safe**: Errors gracefully fall back to API calls
+4. **Visible**: Console logs show cache hits/misses
+5. **Fast**: Local disk reads are near-instant vs API calls
+6. **Production-safe**: Only runs in development mode
+
+## Alternative Approaches Considered
+
+### Option A: Add `'use cache'` to `fetchCloudinaryImageMetadata`
+- **Pro**: Uses Next.js 16 built-in caching
+- **Con**: Dev mode often bypasses/invalidates cache during hot reloads
+- **Con**: Less control over cache behavior
+
+### Option B: Use Next.js `unstable_cache`
+- **Pro**: More explicit than `'use cache'` directive
+- **Con**: Still subject to Next.js dev mode cache invalidation
+- **Con**: API is marked as unstable
+
+### Option C: Redis or in-memory cache
+- **Pro**: Very fast
+- **Con**: Overkill for dev mode, requires additional setup
+- **Con**: In-memory cache lost on server restart
+
+## Files to Modify
+
+1. **Create**: `lib/cache/filesystem.ts` - New cache utility
+2. **Modify**: `lib/cloudinary/fetchCloudinaryImageMetadata.ts` - Add cache layer
+3. **Modify**: `.gitignore` - Add `.local-cache/`
+
+## Success Criteria
+
+- [ ] Cloudinary API calls only made once per unique image during dev session
+- [ ] Cache survives hot reloads and page refreshes
+- [ ] No rate limiting errors during normal dev work
+- [ ] Cache hits logged to console for visibility
+- [ ] Cache directory excluded from git
+- [ ] Errors gracefully fall back to API calls
+- [ ] Only active in development mode
+
+## Notes for Implementation Agent
+
+- Use `fs/promises` for async file operations
+- Ensure directory exists before writing (use `mkdir -p` equivalent)
+- Sanitize public IDs properly (they can contain `/` and other special chars)
+- Keep error handling simple: log and continue
+- Consider adding timestamp to cached data for future TTL support

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ next-env.d.ts
 **/cloudinary/*.json
 .env
 .env.local
+.local-cache/

--- a/lib/cache/filesystem.ts
+++ b/lib/cache/filesystem.ts
@@ -1,0 +1,76 @@
+import { mkdir, readFile, writeFile } from 'fs/promises'
+import { join } from 'path'
+
+/**
+ * Sanitizes a cache key to be safe for use as a filename.
+ * Replaces slashes and other problematic characters with hyphens.
+ */
+function sanitizeCacheKey(key: string): string {
+  return key.replace(/[/\\:*?"<>|]/g, '-')
+}
+
+/**
+ * Gets cached data from the filesystem.
+ * Only operates in development mode.
+ *
+ * @param key - The cache key (will be sanitized for filesystem use)
+ * @param dir - Optional subdirectory within .local-cache (default: 'default')
+ * @returns The cached data if found, null otherwise
+ */
+export async function getCached<T>(key: string, dir: string = 'default'): Promise<T | null> {
+  // Only cache in development mode
+  if (process.env.NODE_ENV !== 'development') {
+    return null
+  }
+
+  try {
+    const sanitizedKey = sanitizeCacheKey(key)
+    const cacheDir = join(process.cwd(), '.local-cache', dir)
+    const filePath = join(cacheDir, `${sanitizedKey}.json`)
+
+    const fileContents = await readFile(filePath, 'utf-8')
+    const parsed = JSON.parse(fileContents)
+
+    console.log(`💾 Cache hit: ${key}`)
+    return parsed.data as T
+  } catch (error) {
+    // Cache miss or read error - not a problem, just return null
+    return null
+  }
+}
+
+/**
+ * Sets cached data in the filesystem.
+ * Only operates in development mode.
+ *
+ * @param key - The cache key (will be sanitized for filesystem use)
+ * @param data - The data to cache (must be JSON-serializable)
+ * @param dir - Optional subdirectory within .local-cache (default: 'default')
+ */
+export async function setCached<T>(key: string, data: T, dir: string = 'default'): Promise<void> {
+  // Only cache in development mode
+  if (process.env.NODE_ENV !== 'development') {
+    return
+  }
+
+  try {
+    const sanitizedKey = sanitizeCacheKey(key)
+    const cacheDir = join(process.cwd(), '.local-cache', dir)
+    const filePath = join(cacheDir, `${sanitizedKey}.json`)
+
+    // Ensure directory exists
+    await mkdir(cacheDir, { recursive: true })
+
+    // Write cache file with timestamp for potential future TTL support
+    const cacheData = {
+      cachedAt: new Date().toISOString(),
+      data,
+    }
+
+    await writeFile(filePath, JSON.stringify(cacheData, null, 2), 'utf-8')
+    console.log(`💾 Cached: ${key}`)
+  } catch (error) {
+    // Log warning but don't throw - caching failures shouldn't break the app
+    console.warn(`⚠️  Failed to cache ${key}:`, error)
+  }
+}

--- a/lib/cloudinary/fetchCloudinaryImageMetadata.ts
+++ b/lib/cloudinary/fetchCloudinaryImageMetadata.ts
@@ -19,12 +19,18 @@ export type CloudinaryImageMetadata = {
  *
  */
 export default async function fetchCloudinaryImageMetadata(url: string): Promise<CloudinaryImageMetadata> {
-  console.log(`📥 Fetching Cloudinary image metadata for "${url}"`)
-
   const publicId = parsePublicIdFromCloudinaryUrl(url)
   if (!publicId) {
     throw new Error(`🚨 Could not parse Cloudinary public ID from URL: "${url}"`)
   }
+
+  // Check cache first (dev mode only)
+  const cached = await getCached<CloudinaryImageMetadata>(publicId, 'cloudinary')
+  if (cached) {
+    return cached
+  }
+
+  console.log(`📥 Fetching Cloudinary image metadata from API for "${publicId}"`)
 
   // Fetch image details from Cloudinary Admin API
   // See: https://cloudinary.com/documentation/admin_api#get_details_of_a_single_resource_by_public_id

--- a/lib/cloudinary/fetchCloudinaryImageMetadata.ts
+++ b/lib/cloudinary/fetchCloudinaryImageMetadata.ts
@@ -1,3 +1,4 @@
+import { getCached, setCached } from '@/lib/cache/filesystem'
 import cloudinary from '@/lib/cloudinary/client'
 import { type CloudinaryResource } from '@/lib/cloudinary/types'
 import { getErrorDetails } from '@/utils/logging'
@@ -103,5 +104,18 @@ export default async function fetchCloudinaryImageMetadata(url: string): Promise
 
   const sizes = '(min-width: 768px) 768px, 100vw'
 
-  return { alt, caption, height, sizes, src, srcSet, width }
+  const metadata: CloudinaryImageMetadata = {
+    alt: alt ?? '',
+    caption: caption ?? '',
+    height,
+    sizes,
+    src,
+    srcSet,
+    width,
+  }
+
+  // Cache the result (dev mode only)
+  await setCached(publicId, metadata, 'cloudinary')
+
+  return metadata
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,10 +2,10 @@ import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
   cacheComponents: true,
-  experimental: {
-    turbopackFileSystemCacheForDev: true,
-  },
-  trailingSlash: true,
+  // experimental: {
+  //   turbopackFileSystemCacheForDev: true,
+  // },
+  trailingSlash: true, // match Astro site norms (which I think apply to RSS feed URLs too)
 }
 
 export default nextConfig

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "cache:clear": "rm -rf .local-cache",
     "format": "prettier --write .",
     "lint": "eslint",
     "start": "next start",


### PR DESCRIPTION
## ✅ What

- Adds `setCached` and `getCached` helpers that save and retrieve JSON-serializable data from `.local-cache/`
- Uses those helper to stash Cloudinary image metadata during development only

## 🤔 Why

- I was hitting Cloudinary admin API rate limits caused by repeatedly fetching the same image metadata
- Those rate limits blocked all UI development until the limit expired (saw error screen instead of app)
- Caching the images locally in a way that survives dev server restarts will make local dev more resilient against offline and other network-related conditions