### PR TITLE
Cache Notion data in filesystem in local development

### DIFF
--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -12,13 +12,16 @@ type Params = {
 
 type Props = Readonly<{
   params: Promise<Params>
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>
 }>
 
-export default async function DynamicRoute({ params }: Props) {
+export default async function DynamicRoute({ params, searchParams }: Props) {
   const slug = (await params).slug
+  const search = await searchParams
+  const skipCache = search.nocache === 'true'
 
   // TODO: use fetch instead? https://nextjs.org/docs/app/api-reference/functions/fetch
-  const post = await getPost({ slug, includeBlocks: true, includePrevAndNext: true })
+  const post = await getPost({ slug, includeBlocks: true, includePrevAndNext: true, skipCache })
   if (!post) {
     notFound()
   }

--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -93,7 +93,7 @@ export default async function DynamicRoute({ params }: Props) {
  * @see https://nextjs.org/docs/app/api-reference/functions/generate-static-params
  */
 export async function generateStaticParams(): Promise<Params[]> {
-  const posts = await getPosts()
+  const posts = await getPosts({ sortDirection: 'ascending' })
   const postSlugs: string[] = posts.map(post => getPropertyValue(post.properties, 'Slug'))
 
   return postSlugs.map(slug => ({ slug }))

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -8,7 +8,7 @@ import Image from '@/ui/image'
 import Heading from '@/ui/heading'
 
 export default async function Blog(): Promise<ReactElement> {
-  const posts = await getPosts('descending')
+  const posts = await getPosts({ sortDirection: 'descending' })
 
   return (
     <main className="flex-auto">

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -7,8 +7,15 @@ import Emoji from '@/ui/emoji'
 import Image from '@/ui/image'
 import Heading from '@/ui/heading'
 
-export default async function Blog(): Promise<ReactElement> {
-  const posts = await getPosts({ sortDirection: 'descending' })
+type Props = Readonly<{
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>
+}>
+
+export default async function Blog({ searchParams }: Props): Promise<ReactElement> {
+  const params = await searchParams
+  const skipCache = params.nocache === 'true'
+
+  const posts = await getPosts({ sortDirection: 'descending', skipCache })
 
   return (
     <main className="flex-auto">

--- a/lib/notion/getPost.ts
+++ b/lib/notion/getPost.ts
@@ -61,7 +61,7 @@ export default async function getPost({
   // TODO: parse with zod
 
   if (includePrevAndNext) {
-    const posts = await getPosts()
+    const posts = await getPosts({ sortDirection: 'ascending' })
     // TODO: parse with zod
 
     const postSlugs: string[] = posts.map(post => getPropertyValue(post.properties, 'Slug'))

--- a/lib/notion/getPost.ts
+++ b/lib/notion/getPost.ts
@@ -73,7 +73,8 @@ export default async function getPost({
   // TODO: parse with zod
 
   if (includePrevAndNext) {
-    const posts = await getPosts({ sortDirection: 'ascending' })
+    // Pass skipCache through to ensure consistent cache behavior
+    const posts = await getPosts({ sortDirection: 'ascending', skipCache })
     // TODO: parse with zod
 
     const postSlugs: string[] = posts.map(post => getPropertyValue(post.properties, 'Slug'))

--- a/lib/notion/getPost.ts
+++ b/lib/notion/getPost.ts
@@ -93,7 +93,8 @@ export default async function getPost({
     post = { ...post, blocks }
   }
 
-  // Cache the result (cache utility handles dev mode check)
+  // Cache the result (always caches, even when skipCache=true)
+  // This ensures ?nocache=true refreshes the cache with latest data
   await setCached(cacheKey, post, 'notion')
 
   return post

--- a/lib/notion/getPost.ts
+++ b/lib/notion/getPost.ts
@@ -73,7 +73,6 @@ export default async function getPost({
   // TODO: parse with zod
 
   if (includePrevAndNext) {
-    // Pass skipCache through to ensure consistent cache behavior
     const posts = await getPosts({ sortDirection: 'ascending', skipCache })
     // TODO: parse with zod
 

--- a/lib/notion/getPosts.ts
+++ b/lib/notion/getPosts.ts
@@ -1,10 +1,8 @@
 import { getCached, setCached } from '@/lib/cache/filesystem'
 import notion, { collectPaginatedAPI } from './client'
 
-type SortDirection = 'ascending' | 'descending'
-
 type Options = {
-  sortDirection?: SortDirection
+  sortDirection?: 'ascending' | 'descending'
   skipCache?: boolean
 }
 

--- a/lib/notion/getPosts.ts
+++ b/lib/notion/getPosts.ts
@@ -50,7 +50,8 @@ export default async function getPosts(options: Options = {}): Promise<any[]> {
 
   // TODO: parse with zod
 
-  // Cache the result (cache utility handles dev mode check)
+  // Cache the result (always caches, even when skipCache=true)
+  // This ensures ?nocache=true refreshes the cache with latest data
   await setCached(cacheKey, posts, 'notion')
 
   return posts

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "dev": "next dev",
     "build": "next build",
     "cache:clear": "rm -rf .local-cache",
+    "cache:clear:cloudinary": "rm -rf .local-cache/cloudinary",
+    "cache:clear:notion": "rm -rf .local-cache/notion",
     "format": "prettier --write .",
     "lint": "eslint",
     "start": "next start",


### PR DESCRIPTION
## ✅ What

- Adds caching to `getPosts()`
- Adds caching to `getPost()` with per-slug granularity
- Adds `?nocache=true` support to /blog page
- Adds `?nocache=true` support to individual post pages
- Adds `npm` scripts for granular cache clearing
   - `npm run cache:clear` - clear everything
   - `npm run cache:clear:notion` - clear just Notion data
   - `npm run cache:clear:cloudinary` - clear just Cloudinary data

## 🤔 Why

- Faster local dev by skipping slow Notion API when repeating same navigations
- More resilient local dev by removing reliance on network by making cached Notion and Cloudinary API results available anytime as a fallback