### PR TITLE
Add support for Notion video blocks

### DIFF
--- a/lib/notion/types.ts
+++ b/lib/notion/types.ts
@@ -23,6 +23,7 @@ import {
   type RichTextItemResponse,
   type QuoteBlockObjectResponse,
   type ToggleBlockObjectResponse,
+  type VideoBlockObjectResponse,
 } from '@notionhq/client'
 import {
   type RichTextItemResponseCommon,
@@ -47,6 +48,7 @@ export type NotionAPIRichTextItem = RichTextItemResponse
 
 export type NotionAPIQuoteBlock = QuoteBlockObjectResponse
 export type NotionAPIToggleBlock = ToggleBlockObjectResponse
+export type NotionAPIVideoBlock = VideoBlockObjectResponse
 
 // Created in NotionBlocks.tsx to group list items so they're easier to render
 export type NotionBulletedListBlock = Omit<BulletedListItemBlockObjectResponse, 'bulleted_list_item' | 'type'> & {

--- a/lib/notion/ui/NotionBlock.tsx
+++ b/lib/notion/ui/NotionBlock.tsx
@@ -9,6 +9,7 @@ import {
   type NotionAPIImageBlock,
   type NotionAPIParagraphBlock,
   type NotionAPIQuoteBlock,
+  type NotionAPIVideoBlock,
   type NotionBulletedListBlock,
   type NotionNumberedListBlock,
 } from '@/lib/notion/types'
@@ -18,6 +19,7 @@ import { Code } from '@/ui/code'
 import Heading from '@/ui/heading'
 import Image from '@/ui/image'
 import Paragraph from '@/ui/paragraph'
+import Video from '@/ui/video'
 
 // TODO: add type definitions for raw Notion blocks + my parsed blocks
 // see: https://github.com/9gustin/react-notion-render/blob/93bc519a4b0e920a0a9b980323c9a1456fab47d5/src/types/NotionBlock.ts
@@ -124,23 +126,13 @@ export default function NotionBlock({ block }: Props): ReactElement {
 
       return <Image url={url} />
 
-    // FIXME: support video embeds
     case 'video':
-      throw new Error('Video blocks not supported yet.')
+      const video = block['video'] satisfies NotionAPIVideoBlock['video']
 
-    // const video = block['video'] satisfies VideoBlock['video']
-    //
-    // // TODO: extract component
-    // return (
-    //   <figure>
-    //     Hi
-    //     <video src={video.type === 'external' ? video.external.url : video.file.url} />
-    //     <video controls>
-    //       <source src={video.type === 'external' ? video.external.url : video.file.url} />
-    //     </video>
-    //     {video.caption && <figcaption>{video.caption ? video.caption[0]?.plain_text : ''}</figcaption>}
-    //   </figure>
-    // )
+      const videoUrl = video.type === 'external' ? video.external.url : video.file.url
+      const videoCaption = video.caption?.[0]?.plain_text
+
+      return <Video url={videoUrl} caption={videoCaption} showCaption={!!videoCaption} />
 
     case 'toggle':
       throw new Error('Toggle blocks not supported yet.')

--- a/ui/video.tsx
+++ b/ui/video.tsx
@@ -58,7 +58,7 @@ export default function Video({ url, showCaption, caption, videoStyles, outerSty
       return <div className={outerClasses}>Unable to load video</div>
     }
 
-    const embedUrl = `https://www.youtube.com/embed/${videoId}`
+    const embedUrl = `https://www.youtube-nocookie.com/embed/${videoId}`
     const iframeClasses = videoStyles ? `${iframeStylesDefault} ${videoStyles}` : iframeStylesDefault
 
     videoElement = (

--- a/ui/video.tsx
+++ b/ui/video.tsx
@@ -44,8 +44,7 @@ export default function Video({ url, showCaption, caption, videoStyles, outerSty
   if (isYouTubeUrl(url)) {
     const videoId = getYouTubeVideoId(url)
     if (!videoId) {
-      console.error(`Failed to extract YouTube video ID from URL: ${url}`)
-      return <div className={outerClasses}>Unable to load video</div>
+      throw new Error(`Failed to extract YouTube video ID from URL: ${url}`)
     }
 
     const embedUrl = `https://www.youtube-nocookie.com/embed/${videoId}`

--- a/ui/video.tsx
+++ b/ui/video.tsx
@@ -1,0 +1,92 @@
+import { type ReactElement } from 'react'
+
+const outerStylesDefault = 'my-6'
+const videoStylesDefault = 'shadow-xl rounded bg-zinc-800 w-full'
+const iframeStylesDefault = 'shadow-xl rounded bg-zinc-800 w-full aspect-video'
+
+type Props = Readonly<{
+  url: string
+  showCaption?: boolean
+  caption?: string
+  videoStyles?: string
+  outerStyles?: string
+}>
+
+/**
+ * Extracts YouTube video ID from various YouTube URL formats.
+ * Supports: youtube.com/watch?v=, youtu.be/, youtube.com/embed/, etc.
+ */
+function getYouTubeVideoId(url: string): string | null {
+  const patterns = [
+    /(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([^&\n?#]+)/,
+    /youtube\.com\/watch\?.*v=([^&\n?#]+)/,
+  ]
+
+  for (const pattern of patterns) {
+    const match = url.match(pattern)
+    if (match && match[1]) {
+      return match[1]
+    }
+  }
+
+  return null
+}
+
+/**
+ * Checks if a URL is a YouTube URL.
+ */
+function isYouTubeUrl(url: string): boolean {
+  return url.includes('youtube.com') || url.includes('youtu.be')
+}
+
+/**
+ * Renders a video element with optional caption.
+ * Automatically detects YouTube URLs and renders them as iframes.
+ * Other video URLs are rendered as HTML5 video elements.
+ *
+ * @returns A JSX element containing the video, optionally wrapped in a figure with a caption.
+ */
+export default function Video({ url, showCaption, caption, videoStyles, outerStyles }: Props) {
+  const outerClasses = outerStyles ? `${outerStylesDefault} ${outerStyles}` : outerStylesDefault
+
+  let videoElement: ReactElement
+
+  if (isYouTubeUrl(url)) {
+    const videoId = getYouTubeVideoId(url)
+    if (!videoId) {
+      console.error(`Failed to extract YouTube video ID from URL: ${url}`)
+      return <div className={outerClasses}>Unable to load video</div>
+    }
+
+    const embedUrl = `https://www.youtube.com/embed/${videoId}`
+    const iframeClasses = videoStyles ? `${iframeStylesDefault} ${videoStyles}` : iframeStylesDefault
+
+    videoElement = (
+      <iframe
+        src={embedUrl}
+        title={caption || 'YouTube video'}
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowFullScreen
+        className={iframeClasses}
+      />
+    )
+  } else {
+    const videoClasses = videoStyles ? `${videoStylesDefault} ${videoStyles}` : videoStylesDefault
+
+    videoElement = (
+      <video controls className={videoClasses}>
+        <source src={url} />
+        Your browser does not support the video tag.
+      </video>
+    )
+  }
+
+  return caption && showCaption ? (
+    <figure className={outerClasses}>
+      {videoElement}
+      <figcaption className="caption">{caption}</figcaption>
+    </figure>
+  ) : (
+    <div className={outerClasses}>{videoElement}</div>
+  )
+}

--- a/ui/video.tsx
+++ b/ui/video.tsx
@@ -34,6 +34,14 @@ function isYouTubeUrl(url: string): boolean {
  * Automatically detects YouTube URLs and renders them as iframes.
  * Other video URLs are rendered as HTML5 video elements.
  *
+ * @example
+ * // YouTube video
+ * <Video url="https://youtube.com/watch?v=abc123" caption="Tutorial" showCaption={true} />
+ *
+ * @example
+ * // Direct video file
+ * <Video url="https://example.com/video.mp4" />
+ *
  * @returns A JSX element containing the video, optionally wrapped in a figure with a caption.
  */
 export default function Video({ url, showCaption, caption, videoStyles, outerStyles }: Props): ReactElement {

--- a/ui/video.tsx
+++ b/ui/video.tsx
@@ -65,7 +65,7 @@ export default function Video({ url, showCaption, caption, videoStyles, outerSty
       <iframe
         src={embedUrl}
         title={caption || 'YouTube video'}
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
         allowFullScreen
         className={iframeClasses}
       />

--- a/ui/video.tsx
+++ b/ui/video.tsx
@@ -17,19 +17,9 @@ type Props = Readonly<{
  * Supports: youtube.com/watch?v=, youtu.be/, youtube.com/embed/, etc.
  */
 function getYouTubeVideoId(url: string): string | null {
-  const patterns = [
-    /(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([^&\n?#]+)/,
-    /youtube\.com\/watch\?.*v=([^&\n?#]+)/,
-  ]
-
-  for (const pattern of patterns) {
-    const match = url.match(pattern)
-    if (match && match[1]) {
-      return match[1]
-    }
-  }
-
-  return null
+  const pattern = /(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([^&\n?#]+)/
+  const match = url.match(pattern)
+  return match?.[1] ?? null
 }
 
 /**
@@ -46,7 +36,7 @@ function isYouTubeUrl(url: string): boolean {
  *
  * @returns A JSX element containing the video, optionally wrapped in a figure with a caption.
  */
-export default function Video({ url, showCaption, caption, videoStyles, outerStyles }: Props) {
+export default function Video({ url, showCaption, caption, videoStyles, outerStyles }: Props): ReactElement {
   const outerClasses = outerStyles ? `${outerStylesDefault} ${outerStyles}` : outerStylesDefault
 
   let videoElement: ReactElement
@@ -66,6 +56,8 @@ export default function Video({ url, showCaption, caption, videoStyles, outerSty
         src={embedUrl}
         title={caption || 'YouTube video'}
         allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+        sandbox="allow-scripts allow-same-origin allow-presentation"
+        loading="lazy"
         allowFullScreen
         className={iframeClasses}
       />
@@ -74,7 +66,7 @@ export default function Video({ url, showCaption, caption, videoStyles, outerSty
     const videoClasses = videoStyles ? `${videoStylesDefault} ${videoStyles}` : videoStylesDefault
 
     videoElement = (
-      <video controls className={videoClasses}>
+      <video controls preload="metadata" playsInline className={videoClasses}>
         <source src={url} />
         Your browser does not support the video tag.
       </video>

--- a/ui/video.tsx
+++ b/ui/video.tsx
@@ -65,7 +65,7 @@ export default function Video({ url, showCaption, caption, videoStyles, outerSty
       <iframe
         src={embedUrl}
         title={caption || 'YouTube video'}
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
         allowFullScreen
         className={iframeClasses}
       />


### PR DESCRIPTION
## ✅ What

- Notion video blocks now render properly (previously threw an error)
- YouTube videos appear as iframe embeds using youtube-nocookie.com for privacy
- Direct video file URLs render as HTML5 video players
- Video captions display when present in Notion

## 🤔 Why

Blog posts with embedded videos (YouTube tutorials, demos, etc.) can now be published without errors.

## 👩‍🔬 How to validate

1. Add a video block to a Notion post (paste a YouTube URL)
2. Visit the post locally with `?nocache=true` to bust the cache
3. Expect to see the YouTube video render in an iframe player
4. Try playing the video - expect it to work normally
5. Add a caption to the video block in Notion
6. Refresh with `?nocache=true` again
7. Expect to see the caption displayed below the video
8. Remove the caption in Notion and refresh
9. Expect no empty caption element to appear
10. Verify the iframe uses `youtube-nocookie.com` (check devtools)