### PR TITLE
Add Playwright MCP server for browser automation

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,3 @@
+{
+  "enableAllProjectMcpServers": true
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,5 +1,9 @@
 {
   "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["@playwright/mcp@latest"]
+    },
     "next-devtools": {
       "command": "npx",
       "args": ["-y", "next-devtools-mcp@latest"]


### PR DESCRIPTION
## What

- Adds Playwright MCP server to enable browser automation in Claude Code
- Configures Claude to enable all project MCP servers by default

## Why

Browser automation allows Claude to test and interact with the Next.js app directly - verifying pages load, checking for errors, and validating functionality without manual browser testing.

## How to validate

1. Open this project in Claude Code
2. Ask Claude to "navigate to localhost:3000 using browser automation"
3. Expect Claude to use Playwright tools to open and interact with the dev server
4. Ask Claude to "take a screenshot of the homepage"
5. Expect to see a screenshot of your Next.js app

## Related links

- [Playwright MCP Documentation](https://github.com/microsoft/playwright-mcp)