### PR TITLE
Apply Result pattern to all external API calls

### DIFF
--- a/app/(prose)/[slug]/page.tsx
+++ b/app/(prose)/[slug]/page.tsx
@@ -20,7 +20,7 @@ export default async function DynamicRoute({ params, searchParams }: Props) {
   const skipCache = search.nocache === 'true'
 
   // TODO: use fetch instead? https://nextjs.org/docs/app/api-reference/functions/fetch
-  const post = await getPost({ slug, includeBlocks: true, includePrevAndNext: true, skipCache })
+  const post = (await getPost({ slug, includeBlocks: true, includePrevAndNext: true, skipCache })).unwrap()
   if (!post) {
     notFound()
   }

--- a/app/(prose)/[slug]/page.tsx
+++ b/app/(prose)/[slug]/page.tsx
@@ -2,7 +2,6 @@ import { notFound } from 'next/navigation'
 
 import getPost from '@/lib/notion/getPost'
 import getPosts from '@/lib/notion/getPosts'
-import { unwrap } from '@/utils/result'
 
 import Post from './ui/post'
 
@@ -96,7 +95,7 @@ export default async function DynamicRoute({ params, searchParams }: Props) {
  * @see https://nextjs.org/docs/app/api-reference/functions/generate-static-params
  */
 export async function generateStaticParams(): Promise<Params[]> {
-  const posts = unwrap(await getPosts({ sortDirection: 'ascending' }))
+  const posts = (await getPosts({ sortDirection: 'ascending' })).unwrap()
 
   return posts.map(post => ({ slug: post.slug }))
 }

--- a/app/(prose)/[slug]/page.tsx
+++ b/app/(prose)/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from 'next/navigation'
 
 import getPost from '@/lib/notion/getPost'
 import getPosts from '@/lib/notion/getPosts'
+import { unwrap } from '@/utils/result'
 
 import Post from './ui/post'
 
@@ -95,7 +96,7 @@ export default async function DynamicRoute({ params, searchParams }: Props) {
  * @see https://nextjs.org/docs/app/api-reference/functions/generate-static-params
  */
 export async function generateStaticParams(): Promise<Params[]> {
-  const posts = await getPosts({ sortDirection: 'ascending' })
+  const posts = unwrap(await getPosts({ sortDirection: 'ascending' }))
 
   return posts.map(post => ({ slug: post.slug }))
 }

--- a/app/(prose)/blog/page.tsx
+++ b/app/(prose)/blog/page.tsx
@@ -3,7 +3,6 @@ import { type ReactElement } from 'react'
 import getPosts from '@/lib/notion/getPosts'
 import Heading from '@/ui/heading'
 import { getHumanReadableDate, getMachineReadableDate } from '@/utils/dates'
-import { unwrap } from '@/utils/result'
 
 type Props = Readonly<{
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>
@@ -13,7 +12,7 @@ export default async function Blog({ searchParams }: Props): Promise<ReactElemen
   const params = await searchParams
   const skipCache = params.nocache === 'true'
 
-  const posts = unwrap(await getPosts({ sortDirection: 'descending', skipCache }))
+  const posts = (await getPosts({ sortDirection: 'descending', skipCache })).unwrap()
 
   return (
     <main className="flex-auto">

--- a/app/(prose)/blog/page.tsx
+++ b/app/(prose)/blog/page.tsx
@@ -3,6 +3,7 @@ import { type ReactElement } from 'react'
 import getPosts from '@/lib/notion/getPosts'
 import Heading from '@/ui/heading'
 import { getHumanReadableDate, getMachineReadableDate } from '@/utils/dates'
+import { unwrap } from '@/utils/result'
 
 type Props = Readonly<{
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>
@@ -12,7 +13,7 @@ export default async function Blog({ searchParams }: Props): Promise<ReactElemen
   const params = await searchParams
   const skipCache = params.nocache === 'true'
 
-  const posts = await getPosts({ sortDirection: 'descending', skipCache })
+  const posts = unwrap(await getPosts({ sortDirection: 'descending', skipCache }))
 
   return (
     <main className="flex-auto">

--- a/app/likes/page.test.tsx
+++ b/app/likes/page.test.tsx
@@ -1,0 +1,153 @@
+import { fetchItunesMedia } from './page'
+import getMediaItems from '@/lib/notion/getMediaItems'
+import fetchItunesItems from '@/lib/itunes/fetchItunesItems'
+import { Ok, Err, isOk, isErr } from '@/utils/result'
+
+// Mock dependencies
+vi.mock('@/lib/notion/getMediaItems')
+vi.mock('@/lib/itunes/fetchItunesItems')
+
+describe('fetchItunesMedia', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('success cases', () => {
+    it('fetches books and enriches with iTunes metadata', async () => {
+      const mockMediaItems = [
+        { appleId: 1, name: 'Book 1', date: '2024-01-15' },
+        { appleId: 2, name: 'Book 2', date: '2024-02-20' },
+      ]
+
+      const mockItunesItems = [
+        { id: '1', title: 'Book 1', date: '2024-01-15', imageUrl: 'https://example.com/1.jpg', imagePlaceholder: 'base64', link: 'https://books.apple.com/1' },
+        { id: '2', title: 'Book 2', date: '2024-02-20', imageUrl: 'https://example.com/2.jpg', imagePlaceholder: 'base64', link: 'https://books.apple.com/2' },
+      ]
+
+      vi.mocked(getMediaItems).mockResolvedValue(Ok(mockMediaItems as any))
+      vi.mocked(fetchItunesItems).mockResolvedValue(Ok(mockItunesItems as any))
+
+      const result = await fetchItunesMedia('books', 'ebook', 'ebook', false)
+
+      expect(isOk(result)).toBe(true)
+      if (isOk(result)) {
+        expect(result.value).toEqual(mockItunesItems)
+      }
+
+      expect(getMediaItems).toHaveBeenCalledWith({ category: 'books', skipCache: false })
+      expect(fetchItunesItems).toHaveBeenCalledWith(
+        [
+          { id: 1, name: 'Book 1', date: '2024-01-15' },
+          { id: 2, name: 'Book 2', date: '2024-02-20' },
+        ],
+        'ebook',
+        'ebook',
+      )
+    })
+
+    it('fetches albums with correct iTunes parameters', async () => {
+      const mockMediaItems = [
+        { appleId: 123, name: 'Album 1', date: '2024-03-10' },
+      ]
+
+      const mockItunesItems = [
+        { id: '123', title: 'Album 1', artist: 'Artist 1', date: '2024-03-10', imageUrl: 'https://example.com/1.jpg', imagePlaceholder: 'base64', link: 'https://music.apple.com/123' },
+      ]
+
+      vi.mocked(getMediaItems).mockResolvedValue(Ok(mockMediaItems as any))
+      vi.mocked(fetchItunesItems).mockResolvedValue(Ok(mockItunesItems as any))
+
+      const result = await fetchItunesMedia('albums', 'music', 'album', true)
+
+      expect(isOk(result)).toBe(true)
+      expect(getMediaItems).toHaveBeenCalledWith({ category: 'albums', skipCache: true })
+      expect(fetchItunesItems).toHaveBeenCalledWith(
+        [{ id: 123, name: 'Album 1', date: '2024-03-10' }],
+        'music',
+        'album',
+      )
+    })
+
+    it('fetches podcasts with correct iTunes parameters', async () => {
+      const mockMediaItems = [
+        { appleId: 456, name: 'Podcast 1', date: '2024-04-01' },
+      ]
+
+      const mockItunesItems = [
+        { id: '456', title: 'Podcast 1', date: '2024-04-01', imageUrl: 'https://example.com/1.jpg', imagePlaceholder: 'base64', link: 'https://podcasts.apple.com/456' },
+      ]
+
+      vi.mocked(getMediaItems).mockResolvedValue(Ok(mockMediaItems as any))
+      vi.mocked(fetchItunesItems).mockResolvedValue(Ok(mockItunesItems as any))
+
+      const result = await fetchItunesMedia('podcasts', 'podcast', 'podcast', false)
+
+      expect(isOk(result)).toBe(true)
+      expect(getMediaItems).toHaveBeenCalledWith({ category: 'podcasts', skipCache: false })
+      expect(fetchItunesItems).toHaveBeenCalledWith(
+        [{ id: 456, name: 'Podcast 1', date: '2024-04-01' }],
+        'podcast',
+        'podcast',
+      )
+    })
+  })
+
+  describe('error propagation', () => {
+    it('returns Err when getMediaItems fails', async () => {
+      const mediaError = new Error('Failed to fetch media items from Notion')
+      vi.mocked(getMediaItems).mockResolvedValue(Err(mediaError))
+
+      const result = await fetchItunesMedia('books', 'ebook', 'ebook', false)
+
+      expect(isErr(result)).toBe(true)
+      if (isErr(result)) {
+        expect(result.error).toBe(mediaError)
+      }
+
+      // Should not call fetchItunesItems if getMediaItems fails
+      expect(fetchItunesItems).not.toHaveBeenCalled()
+    })
+
+    it('returns Err when fetchItunesItems fails', async () => {
+      const mockMediaItems = [
+        { appleId: 1, name: 'Book 1', date: '2024-01-15' },
+      ]
+
+      const itunesError = new Error('iTunes API error')
+      vi.mocked(getMediaItems).mockResolvedValue(Ok(mockMediaItems as any))
+      vi.mocked(fetchItunesItems).mockResolvedValue(Err(itunesError))
+
+      const result = await fetchItunesMedia('books', 'ebook', 'ebook', false)
+
+      expect(isErr(result)).toBe(true)
+      if (isErr(result)) {
+        expect(result.error).toBe(itunesError)
+      }
+    })
+  })
+
+  describe('data transformation', () => {
+    it('correctly maps media items to iTunes lookup format', async () => {
+      const mockMediaItems = [
+        { appleId: 111, name: 'Item 1', date: '2024-01-01', otherField: 'ignored' },
+        { appleId: 222, name: 'Item 2', date: '2024-02-02', otherField: 'ignored' },
+        { appleId: 333, name: 'Item 3', date: '2024-03-03', otherField: 'ignored' },
+      ]
+
+      vi.mocked(getMediaItems).mockResolvedValue(Ok(mockMediaItems as any))
+      vi.mocked(fetchItunesItems).mockResolvedValue(Ok([] as any))
+
+      await fetchItunesMedia('books', 'ebook', 'ebook', false)
+
+      expect(fetchItunesItems).toHaveBeenCalledWith(
+        [
+          { id: 111, name: 'Item 1', date: '2024-01-01' },
+          { id: 222, name: 'Item 2', date: '2024-02-02' },
+          { id: 333, name: 'Item 3', date: '2024-03-03' },
+        ],
+        'ebook',
+        'ebook',
+      )
+    })
+  })
+})

--- a/app/likes/page.tsx
+++ b/app/likes/page.tsx
@@ -79,6 +79,7 @@ export default async function Likes({ searchParams }: PageProps): Promise<ReactE
     fetchTmdbList(TMDB_TV_LIST_ID, 'tv').then(unwrap),
     fetchTmdbList(TMDB_MOVIE_LIST_ID, 'movie').then(unwrap),
     getMediaItems({ category: 'books', skipCache })
+      .then(unwrap)
       .then((items) =>
         fetchItunesItems(
           items.map((i) => ({ id: i.appleId, name: i.name, date: i.date })),
@@ -88,6 +89,7 @@ export default async function Likes({ searchParams }: PageProps): Promise<ReactE
       )
       .then(unwrap),
     getMediaItems({ category: 'albums', skipCache })
+      .then(unwrap)
       .then((items) =>
         fetchItunesItems(
           items.map((i) => ({ id: i.appleId, name: i.name, date: i.date })),
@@ -97,6 +99,7 @@ export default async function Likes({ searchParams }: PageProps): Promise<ReactE
       )
       .then(unwrap),
     getMediaItems({ category: 'podcasts', skipCache })
+      .then(unwrap)
       .then((items) =>
         fetchItunesItems(
           items.map((i) => ({ id: i.appleId, name: i.name, date: i.date })),

--- a/app/likes/page.tsx
+++ b/app/likes/page.tsx
@@ -6,6 +6,7 @@ import fetchTmdbList, { type TmdbItem } from '@/lib/tmdb/fetchTmdbList'
 import getMediaItems from '@/lib/notion/getMediaItems'
 import fetchItunesItems, { type iTunesItem } from '@/lib/itunes/fetchItunesItems'
 import { env } from '@/lib/env'
+import { unwrap } from '@/utils/result'
 
 export const metadata: Metadata = {
   title: 'Likes - Michael Uloth',
@@ -77,25 +78,31 @@ export default async function Likes({ searchParams }: PageProps): Promise<ReactE
   const [tv, movies, books, albums, podcasts] = await Promise.all([
     fetchTmdbList(TMDB_TV_LIST_ID, 'tv'),
     fetchTmdbList(TMDB_MOVIE_LIST_ID, 'movie'),
-    getMediaItems({ category: 'books', skipCache }).then(items =>
-      fetchItunesItems(
-        items.map(i => ({ id: i.appleId, name: i.name, date: i.date })),
-        'ebook',
-        'ebook',
+    getMediaItems({ category: 'books', skipCache }).then(async items =>
+      unwrap(
+        await fetchItunesItems(
+          items.map(i => ({ id: i.appleId, name: i.name, date: i.date })),
+          'ebook',
+          'ebook',
+        ),
       ),
     ),
-    getMediaItems({ category: 'albums', skipCache }).then(items =>
-      fetchItunesItems(
-        items.map(i => ({ id: i.appleId, name: i.name, date: i.date })),
-        'music',
-        'album',
+    getMediaItems({ category: 'albums', skipCache }).then(async items =>
+      unwrap(
+        await fetchItunesItems(
+          items.map(i => ({ id: i.appleId, name: i.name, date: i.date })),
+          'music',
+          'album',
+        ),
       ),
     ),
-    getMediaItems({ category: 'podcasts', skipCache }).then(items =>
-      fetchItunesItems(
-        items.map(i => ({ id: i.appleId, name: i.name, date: i.date })),
-        'podcast',
-        'podcast',
+    getMediaItems({ category: 'podcasts', skipCache }).then(async items =>
+      unwrap(
+        await fetchItunesItems(
+          items.map(i => ({ id: i.appleId, name: i.name, date: i.date })),
+          'podcast',
+          'podcast',
+        ),
       ),
     ),
   ])

--- a/app/likes/page.tsx
+++ b/app/likes/page.tsx
@@ -6,6 +6,7 @@ import fetchTmdbList, { type TmdbItem } from '@/lib/tmdb/fetchTmdbList'
 import getMediaItems from '@/lib/notion/getMediaItems'
 import fetchItunesItems, { type iTunesItem } from '@/lib/itunes/fetchItunesItems'
 import { env } from '@/lib/env'
+import { type Result } from '@/utils/result'
 
 export const metadata: Metadata = {
   title: 'Likes - Michael Uloth',
@@ -14,6 +15,32 @@ export const metadata: Metadata = {
 
 const TMDB_TV_LIST_ID = env.TMDB_TV_LIST_ID
 const TMDB_MOVIE_LIST_ID = env.TMDB_MOVIE_LIST_ID
+
+type iTunesMedium = 'ebook' | 'music' | 'podcast'
+type iTunesEntity = 'ebook' | 'album' | 'podcast'
+type MediaCategory = 'books' | 'albums' | 'podcasts'
+
+/**
+ * Fetches media items from Notion and enriches with iTunes metadata.
+ * Returns Result to enable explicit error propagation without intermediate unwraps.
+ */
+export async function fetchItunesMedia(
+  category: MediaCategory,
+  medium: iTunesMedium,
+  entity: iTunesEntity,
+  skipCache: boolean,
+): Promise<Result<iTunesItem[], Error>> {
+  const itemsResult = await getMediaItems({ category, skipCache })
+  if (!itemsResult.ok) {
+    return itemsResult
+  }
+
+  return fetchItunesItems(
+    itemsResult.value.map((i) => ({ id: i.appleId, name: i.name, date: i.date })),
+    medium,
+    entity,
+  )
+}
 
 type MediaSectionProps = {
   title: string
@@ -77,36 +104,9 @@ export default async function Likes({ searchParams }: PageProps): Promise<ReactE
   const [tv, movies, books, albums, podcasts] = await Promise.all([
     fetchTmdbList(TMDB_TV_LIST_ID, 'tv').then((r) => r.unwrap()),
     fetchTmdbList(TMDB_MOVIE_LIST_ID, 'movie').then((r) => r.unwrap()),
-    getMediaItems({ category: 'books', skipCache })
-      .then((r) => r.unwrap())
-      .then((items) =>
-        fetchItunesItems(
-          items.map((i) => ({ id: i.appleId, name: i.name, date: i.date })),
-          'ebook',
-          'ebook',
-        ),
-      )
-      .then((r) => r.unwrap()),
-    getMediaItems({ category: 'albums', skipCache })
-      .then((r) => r.unwrap())
-      .then((items) =>
-        fetchItunesItems(
-          items.map((i) => ({ id: i.appleId, name: i.name, date: i.date })),
-          'music',
-          'album',
-        ),
-      )
-      .then((r) => r.unwrap()),
-    getMediaItems({ category: 'podcasts', skipCache })
-      .then((r) => r.unwrap())
-      .then((items) =>
-        fetchItunesItems(
-          items.map((i) => ({ id: i.appleId, name: i.name, date: i.date })),
-          'podcast',
-          'podcast',
-        ),
-      )
-      .then((r) => r.unwrap()),
+    fetchItunesMedia('books', 'ebook', 'ebook', skipCache).then((r) => r.unwrap()),
+    fetchItunesMedia('albums', 'music', 'album', skipCache).then((r) => r.unwrap()),
+    fetchItunesMedia('podcasts', 'podcast', 'podcast', skipCache).then((r) => r.unwrap()),
   ])
 
   return (

--- a/app/likes/page.tsx
+++ b/app/likes/page.tsx
@@ -76,8 +76,8 @@ export default async function Likes({ searchParams }: PageProps): Promise<ReactE
 
   // Fetch all categories in parallel
   const [tv, movies, books, albums, podcasts] = await Promise.all([
-    fetchTmdbList(TMDB_TV_LIST_ID, 'tv'),
-    fetchTmdbList(TMDB_MOVIE_LIST_ID, 'movie'),
+    fetchTmdbList(TMDB_TV_LIST_ID, 'tv').then(unwrap),
+    fetchTmdbList(TMDB_MOVIE_LIST_ID, 'movie').then(unwrap),
     getMediaItems({ category: 'books', skipCache }).then(async items =>
       unwrap(
         await fetchItunesItems(

--- a/app/likes/page.tsx
+++ b/app/likes/page.tsx
@@ -6,7 +6,6 @@ import fetchTmdbList, { type TmdbItem } from '@/lib/tmdb/fetchTmdbList'
 import getMediaItems from '@/lib/notion/getMediaItems'
 import fetchItunesItems, { type iTunesItem } from '@/lib/itunes/fetchItunesItems'
 import { env } from '@/lib/env'
-import { unwrap } from '@/utils/result'
 
 export const metadata: Metadata = {
   title: 'Likes - Michael Uloth',
@@ -76,10 +75,10 @@ export default async function Likes({ searchParams }: PageProps): Promise<ReactE
 
   // Fetch all categories in parallel
   const [tv, movies, books, albums, podcasts] = await Promise.all([
-    fetchTmdbList(TMDB_TV_LIST_ID, 'tv').then(unwrap),
-    fetchTmdbList(TMDB_MOVIE_LIST_ID, 'movie').then(unwrap),
+    fetchTmdbList(TMDB_TV_LIST_ID, 'tv').then((r) => r.unwrap()),
+    fetchTmdbList(TMDB_MOVIE_LIST_ID, 'movie').then((r) => r.unwrap()),
     getMediaItems({ category: 'books', skipCache })
-      .then(unwrap)
+      .then((r) => r.unwrap())
       .then((items) =>
         fetchItunesItems(
           items.map((i) => ({ id: i.appleId, name: i.name, date: i.date })),
@@ -87,9 +86,9 @@ export default async function Likes({ searchParams }: PageProps): Promise<ReactE
           'ebook',
         ),
       )
-      .then(unwrap),
+      .then((r) => r.unwrap()),
     getMediaItems({ category: 'albums', skipCache })
-      .then(unwrap)
+      .then((r) => r.unwrap())
       .then((items) =>
         fetchItunesItems(
           items.map((i) => ({ id: i.appleId, name: i.name, date: i.date })),
@@ -97,9 +96,9 @@ export default async function Likes({ searchParams }: PageProps): Promise<ReactE
           'album',
         ),
       )
-      .then(unwrap),
+      .then((r) => r.unwrap()),
     getMediaItems({ category: 'podcasts', skipCache })
-      .then(unwrap)
+      .then((r) => r.unwrap())
       .then((items) =>
         fetchItunesItems(
           items.map((i) => ({ id: i.appleId, name: i.name, date: i.date })),
@@ -107,7 +106,7 @@ export default async function Likes({ searchParams }: PageProps): Promise<ReactE
           'podcast',
         ),
       )
-      .then(unwrap),
+      .then((r) => r.unwrap()),
   ])
 
   return (

--- a/app/likes/page.tsx
+++ b/app/likes/page.tsx
@@ -78,33 +78,33 @@ export default async function Likes({ searchParams }: PageProps): Promise<ReactE
   const [tv, movies, books, albums, podcasts] = await Promise.all([
     fetchTmdbList(TMDB_TV_LIST_ID, 'tv').then(unwrap),
     fetchTmdbList(TMDB_MOVIE_LIST_ID, 'movie').then(unwrap),
-    getMediaItems({ category: 'books', skipCache }).then(async items =>
-      unwrap(
-        await fetchItunesItems(
-          items.map(i => ({ id: i.appleId, name: i.name, date: i.date })),
+    getMediaItems({ category: 'books', skipCache })
+      .then((items) =>
+        fetchItunesItems(
+          items.map((i) => ({ id: i.appleId, name: i.name, date: i.date })),
           'ebook',
           'ebook',
         ),
-      ),
-    ),
-    getMediaItems({ category: 'albums', skipCache }).then(async items =>
-      unwrap(
-        await fetchItunesItems(
-          items.map(i => ({ id: i.appleId, name: i.name, date: i.date })),
+      )
+      .then(unwrap),
+    getMediaItems({ category: 'albums', skipCache })
+      .then((items) =>
+        fetchItunesItems(
+          items.map((i) => ({ id: i.appleId, name: i.name, date: i.date })),
           'music',
           'album',
         ),
-      ),
-    ),
-    getMediaItems({ category: 'podcasts', skipCache }).then(async items =>
-      unwrap(
-        await fetchItunesItems(
-          items.map(i => ({ id: i.appleId, name: i.name, date: i.date })),
+      )
+      .then(unwrap),
+    getMediaItems({ category: 'podcasts', skipCache })
+      .then((items) =>
+        fetchItunesItems(
+          items.map((i) => ({ id: i.appleId, name: i.name, date: i.date })),
           'podcast',
           'podcast',
         ),
-      ),
-    ),
+      )
+      .then(unwrap),
   ])
 
   return (

--- a/lib/cloudinary/fetchCloudinaryImageMetadata.test.ts
+++ b/lib/cloudinary/fetchCloudinaryImageMetadata.test.ts
@@ -1,0 +1,318 @@
+import fetchCloudinaryImageMetadata from './fetchCloudinaryImageMetadata'
+import { isOk, isErr } from '@/utils/result'
+import type { CloudinaryResource } from './types'
+
+// Mock dependencies
+vi.mock('./client', () => ({
+  default: {
+    api: {
+      resource: vi.fn(),
+    },
+    url: vi.fn((publicId: string, options: any) => {
+      return `https://res.cloudinary.com/test/image/upload/w_${options.width}/${publicId}`
+    }),
+  },
+}))
+
+vi.mock('@/lib/cache/filesystem', () => ({
+  getCached: vi.fn(),
+  setCached: vi.fn(),
+}))
+
+vi.mock('./parsePublicIdFromCloudinaryUrl', () => ({
+  default: vi.fn(),
+}))
+
+describe('fetchCloudinaryImageMetadata', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('success cases', () => {
+    it('returns Ok with image metadata from Cloudinary API', async () => {
+      const cloudinary = (await import('./client')).default
+      const { getCached, setCached } = await import('@/lib/cache/filesystem')
+      const parsePublicIdFromCloudinaryUrl = (await import('./parsePublicIdFromCloudinaryUrl')).default
+
+      vi.mocked(getCached).mockResolvedValue(null)
+      vi.mocked(parsePublicIdFromCloudinaryUrl).mockReturnValue('sample/image')
+
+      const mockCloudinaryResource: CloudinaryResource = {
+        public_id: 'sample/image',
+        width: 1200,
+        height: 800,
+        context: {
+          custom: {
+            alt: 'Test image',
+            caption: 'Test caption',
+          },
+        },
+      } as any
+
+      vi.mocked(cloudinary.api.resource).mockResolvedValue(mockCloudinaryResource)
+
+      const result = await fetchCloudinaryImageMetadata('https://res.cloudinary.com/test/image.jpg')
+
+      expect(isOk(result)).toBe(true)
+      if (isOk(result)) {
+        expect(result.value).toMatchObject({
+          alt: 'Test image',
+          caption: 'Test caption',
+          width: 1200,
+          height: 800,
+          sizes: '(min-width: 768px) 768px, 100vw',
+        })
+        expect(result.value.src).toContain('w_1440')
+        expect(result.value.srcSet).toContain('350w')
+        expect(result.value.srcSet).toContain('2160w')
+      }
+
+      expect(cloudinary.api.resource).toHaveBeenCalledWith('sample/image', {
+        context: true,
+        type: 'upload',
+      })
+
+      expect(setCached).toHaveBeenCalledWith('sample/image', expect.any(Object), 'cloudinary')
+    })
+
+    it('returns Ok with cached metadata when available', async () => {
+      const { getCached } = await import('@/lib/cache/filesystem')
+      const parsePublicIdFromCloudinaryUrl = (await import('./parsePublicIdFromCloudinaryUrl')).default
+
+      vi.mocked(parsePublicIdFromCloudinaryUrl).mockReturnValue('sample/image')
+
+      const cachedMetadata = {
+        alt: 'Cached image',
+        caption: 'Cached caption',
+        width: 1000,
+        height: 600,
+        sizes: '(min-width: 768px) 768px, 100vw',
+        src: 'https://cached.com/image.jpg',
+        srcSet: 'https://cached.com/image-350.jpg 350w',
+      }
+
+      vi.mocked(getCached).mockResolvedValue(cachedMetadata)
+
+      const result = await fetchCloudinaryImageMetadata('https://res.cloudinary.com/test/image.jpg')
+
+      expect(isOk(result)).toBe(true)
+      if (isOk(result)) {
+        expect(result.value).toEqual(cachedMetadata)
+      }
+    })
+
+    it('handles images with missing alt text', async () => {
+      const cloudinary = (await import('./client')).default
+      const { getCached } = await import('@/lib/cache/filesystem')
+      const parsePublicIdFromCloudinaryUrl = (await import('./parsePublicIdFromCloudinaryUrl')).default
+
+      vi.mocked(getCached).mockResolvedValue(null)
+      vi.mocked(parsePublicIdFromCloudinaryUrl).mockReturnValue('sample/image')
+
+      const mockCloudinaryResource: CloudinaryResource = {
+        public_id: 'sample/image',
+        width: 1200,
+        height: 800,
+        context: {
+          custom: {
+            caption: 'Test caption',
+          },
+        },
+      } as any
+
+      vi.mocked(cloudinary.api.resource).mockResolvedValue(mockCloudinaryResource)
+
+      const result = await fetchCloudinaryImageMetadata('https://res.cloudinary.com/test/image.jpg')
+
+      expect(isOk(result)).toBe(true)
+      if (isOk(result)) {
+        expect(result.value.alt).toBe('') // Empty string when alt is missing
+        expect(result.value.caption).toBe('Test caption')
+      }
+    })
+
+    it('handles images with missing caption', async () => {
+      const cloudinary = (await import('./client')).default
+      const { getCached } = await import('@/lib/cache/filesystem')
+      const parsePublicIdFromCloudinaryUrl = (await import('./parsePublicIdFromCloudinaryUrl')).default
+
+      vi.mocked(getCached).mockResolvedValue(null)
+      vi.mocked(parsePublicIdFromCloudinaryUrl).mockReturnValue('sample/image')
+
+      const mockCloudinaryResource: CloudinaryResource = {
+        public_id: 'sample/image',
+        width: 1200,
+        height: 800,
+        context: {
+          custom: {
+            alt: 'Test image',
+          },
+        },
+      } as any
+
+      vi.mocked(cloudinary.api.resource).mockResolvedValue(mockCloudinaryResource)
+
+      const result = await fetchCloudinaryImageMetadata('https://res.cloudinary.com/test/image.jpg')
+
+      expect(isOk(result)).toBe(true)
+      if (isOk(result)) {
+        expect(result.value.alt).toBe('Test image')
+        expect(result.value.caption).toBe('') // Empty string when caption is missing
+      }
+    })
+
+    it('uses type "fetch" for URLs starting with http', async () => {
+      const cloudinary = (await import('./client')).default
+      const { getCached } = await import('@/lib/cache/filesystem')
+      const parsePublicIdFromCloudinaryUrl = (await import('./parsePublicIdFromCloudinaryUrl')).default
+
+      vi.mocked(getCached).mockResolvedValue(null)
+      vi.mocked(parsePublicIdFromCloudinaryUrl).mockReturnValue('http://example.com/image.jpg')
+
+      const mockCloudinaryResource: CloudinaryResource = {
+        public_id: 'http://example.com/image.jpg',
+        width: 1200,
+        height: 800,
+        context: {
+          custom: {
+            alt: 'Test',
+          },
+        },
+      } as any
+
+      vi.mocked(cloudinary.api.resource).mockResolvedValue(mockCloudinaryResource)
+
+      const result = await fetchCloudinaryImageMetadata('https://cloudinary.com/fetch/image.jpg')
+
+      expect(isOk(result)).toBe(true)
+      expect(cloudinary.api.resource).toHaveBeenCalledWith('http://example.com/image.jpg', {
+        context: true,
+        type: 'fetch',
+      })
+    })
+  })
+
+  describe('error cases', () => {
+    it('returns Err when URL cannot be parsed', async () => {
+      const parsePublicIdFromCloudinaryUrl = (await import('./parsePublicIdFromCloudinaryUrl')).default
+      vi.mocked(parsePublicIdFromCloudinaryUrl).mockReturnValue(null)
+
+      const result = await fetchCloudinaryImageMetadata('https://invalid-url.com')
+
+      expect(isErr(result)).toBe(true)
+      if (isErr(result)) {
+        expect(result.error.message).toContain('Could not parse Cloudinary public ID')
+      }
+    })
+
+    it('returns Err when Cloudinary API call fails', async () => {
+      const cloudinary = (await import('./client')).default
+      const { getCached } = await import('@/lib/cache/filesystem')
+      const parsePublicIdFromCloudinaryUrl = (await import('./parsePublicIdFromCloudinaryUrl')).default
+
+      vi.mocked(getCached).mockResolvedValue(null)
+      vi.mocked(parsePublicIdFromCloudinaryUrl).mockReturnValue('sample/image')
+
+      const apiError = new Error('Cloudinary API error')
+      vi.mocked(cloudinary.api.resource).mockRejectedValue(apiError)
+
+      const result = await fetchCloudinaryImageMetadata('https://res.cloudinary.com/test/image.jpg')
+
+      expect(isErr(result)).toBe(true)
+      if (isErr(result)) {
+        expect(result.error.message).toContain('Error fetching Cloudinary image')
+      }
+    })
+
+    it('returns Err when image is missing width', async () => {
+      const cloudinary = (await import('./client')).default
+      const { getCached } = await import('@/lib/cache/filesystem')
+      const parsePublicIdFromCloudinaryUrl = (await import('./parsePublicIdFromCloudinaryUrl')).default
+
+      vi.mocked(getCached).mockResolvedValue(null)
+      vi.mocked(parsePublicIdFromCloudinaryUrl).mockReturnValue('sample/image')
+
+      const mockCloudinaryResource: CloudinaryResource = {
+        public_id: 'sample/image',
+        height: 800,
+        context: {
+          custom: {
+            alt: 'Test',
+          },
+        },
+      } as any
+
+      vi.mocked(cloudinary.api.resource).mockResolvedValue(mockCloudinaryResource)
+
+      const result = await fetchCloudinaryImageMetadata('https://res.cloudinary.com/test/image.jpg')
+
+      expect(isErr(result)).toBe(true)
+      if (isErr(result)) {
+        expect(result.error.message).toContain('missing width metadata')
+      }
+    })
+
+    it('returns Err when image is missing height', async () => {
+      const cloudinary = (await import('./client')).default
+      const { getCached } = await import('@/lib/cache/filesystem')
+      const parsePublicIdFromCloudinaryUrl = (await import('./parsePublicIdFromCloudinaryUrl')).default
+
+      vi.mocked(getCached).mockResolvedValue(null)
+      vi.mocked(parsePublicIdFromCloudinaryUrl).mockReturnValue('sample/image')
+
+      const mockCloudinaryResource: CloudinaryResource = {
+        public_id: 'sample/image',
+        width: 1200,
+        context: {
+          custom: {
+            alt: 'Test',
+          },
+        },
+      } as any
+
+      vi.mocked(cloudinary.api.resource).mockResolvedValue(mockCloudinaryResource)
+
+      const result = await fetchCloudinaryImageMetadata('https://res.cloudinary.com/test/image.jpg')
+
+      expect(isErr(result)).toBe(true)
+      if (isErr(result)) {
+        expect(result.error.message).toContain('missing height metadata')
+      }
+    })
+
+    it('returns Err when cache read fails', async () => {
+      const { getCached } = await import('@/lib/cache/filesystem')
+      const parsePublicIdFromCloudinaryUrl = (await import('./parsePublicIdFromCloudinaryUrl')).default
+
+      vi.mocked(parsePublicIdFromCloudinaryUrl).mockReturnValue('sample/image')
+
+      const cacheError = new Error('Cache read error')
+      vi.mocked(getCached).mockRejectedValue(cacheError)
+
+      const result = await fetchCloudinaryImageMetadata('https://res.cloudinary.com/test/image.jpg')
+
+      expect(isErr(result)).toBe(true)
+      if (isErr(result)) {
+        expect(result.error).toBe(cacheError)
+      }
+    })
+
+    it('wraps non-Error exceptions as Error', async () => {
+      const cloudinary = (await import('./client')).default
+      const { getCached } = await import('@/lib/cache/filesystem')
+      const parsePublicIdFromCloudinaryUrl = (await import('./parsePublicIdFromCloudinaryUrl')).default
+
+      vi.mocked(getCached).mockResolvedValue(null)
+      vi.mocked(parsePublicIdFromCloudinaryUrl).mockReturnValue('sample/image')
+      vi.mocked(cloudinary.api.resource).mockRejectedValue('string error')
+
+      const result = await fetchCloudinaryImageMetadata('https://res.cloudinary.com/test/image.jpg')
+
+      expect(isErr(result)).toBe(true)
+      if (isErr(result)) {
+        expect(result.error).toBeInstanceOf(Error)
+        expect(result.error.message).toContain('string error')
+      }
+    })
+  })
+})

--- a/lib/cloudinary/fetchCloudinaryImageMetadata.ts
+++ b/lib/cloudinary/fetchCloudinaryImageMetadata.ts
@@ -3,6 +3,7 @@ import cloudinary from '@/lib/cloudinary/client'
 import { type CloudinaryResource } from '@/lib/cloudinary/types'
 import { getErrorDetails } from '@/utils/logging'
 import parsePublicIdFromCloudinaryUrl from './parsePublicIdFromCloudinaryUrl'
+import { Ok, Err, type Result } from '@/utils/result'
 
 export type CloudinaryImageMetadata = {
   alt: string
@@ -18,110 +19,117 @@ export type CloudinaryImageMetadata = {
  * Fetches Cloudinary image metadata including alt text, caption, dimensions, and responsive image attributes.
  *
  */
-export default async function fetchCloudinaryImageMetadata(url: string): Promise<CloudinaryImageMetadata> {
-  const publicId = parsePublicIdFromCloudinaryUrl(url)
-  if (!publicId) {
-    throw new Error(`🚨 Could not parse Cloudinary public ID from URL: "${url}"`)
-  }
-
-  // Check cache first (dev mode only)
-  const cached = await getCached<CloudinaryImageMetadata>(publicId, 'cloudinary')
-  if (cached) {
-    return cached
-  }
-
-  console.log(`📥 Fetching Cloudinary image metadata from API for "${publicId}"`)
-
-  // Fetch image details from Cloudinary Admin API
-  // See: https://cloudinary.com/documentation/admin_api#get_details_of_a_single_resource_by_public_id
-  const cloudinaryImage: CloudinaryResource = await cloudinary.api
-    .resource(publicId, {
-      context: true, // include contextual metadata (alt, caption, plus any custom fields)
-      type: publicId.startsWith('http') ? 'fetch' : 'upload',
-    })
-    .catch(error => {
-      throw Error(`🚨 Error fetching Cloudinary image: "${publicId}":\n\n${getErrorDetails(error)}\n`)
-    })
-
-  // TODO: parse image with zod (api uses type "object" for context and metadata)
-
-  type CloudinaryImageContext = {
-    custom: {
-      alt?: string
-      caption?: string
+export default async function fetchCloudinaryImageMetadata(
+  url: string,
+): Promise<Result<CloudinaryImageMetadata, Error>> {
+  try {
+    const publicId = parsePublicIdFromCloudinaryUrl(url)
+    if (!publicId) {
+      throw new Error(`🚨 Could not parse Cloudinary public ID from URL: "${url}"`)
     }
+
+    // Check cache first (dev mode only)
+    const cached = await getCached<CloudinaryImageMetadata>(publicId, 'cloudinary')
+    if (cached) {
+      return Ok(cached)
+    }
+
+    console.log(`📥 Fetching Cloudinary image metadata from API for "${publicId}"`)
+
+    // Fetch image details from Cloudinary Admin API
+    // See: https://cloudinary.com/documentation/admin_api#get_details_of_a_single_resource_by_public_id
+    const cloudinaryImage: CloudinaryResource = await cloudinary.api
+      .resource(publicId, {
+        context: true, // include contextual metadata (alt, caption, plus any custom fields)
+        type: publicId.startsWith('http') ? 'fetch' : 'upload',
+      })
+      .catch(error => {
+        throw Error(`🚨 Error fetching Cloudinary image: "${publicId}":\n\n${getErrorDetails(error)}\n`)
+      })
+
+    // TODO: parse image with zod (api uses type "object" for context and metadata)
+
+    type CloudinaryImageContext = {
+      custom: {
+        alt?: string
+        caption?: string
+      }
+    }
+
+    const alt = (cloudinaryImage.context as CloudinaryImageContext)?.custom.alt // "custom" property currently defined as type "object" by sdk
+
+    if (!alt) {
+      // TODO: restore strictness? I disabled it after a couple "/fetch/" gifs were missing all contextual metadata
+      console.error(`🚨 Cloudinary image "${publicId}" is missing alt text in contextual metadata.`)
+      // throw new Error(`🚨 Cloudinary image "${publicId}" is missing alt text in contextual metadata.`)
+    }
+
+    const caption = (cloudinaryImage.context as CloudinaryImageContext)?.custom.caption // comes from "Title" field in contextual metadata
+
+    const width = cloudinaryImage.width
+    if (typeof width !== 'number') {
+      throw new Error(`🚨 Cloudinary image "${publicId}" is missing width metadata.`)
+    }
+
+    const height = cloudinaryImage.height
+    if (typeof height !== 'number') {
+      throw new Error(`🚨 Cloudinary image "${publicId}" is missing height metadata.`)
+    }
+
+    // console.log(`✅ Fetched Cloudinary image metadata for "${url}"`)
+
+    // TODO: separate into multiple functions: (1) fetch cloudinary image metadata from (2) update image metadata logic
+    const widths = [
+      350, // image layout width on phone at 1x DPR
+      700, // image layout width on phone at 2x DPR
+      850,
+      1020,
+      1200, // image layout width on phone at 3x DPR
+      1440, // max image layout width at 2x DPR (skipped 1x since 700px is already included above)
+      1680,
+      1920,
+      2160, // max image layout width at 3x DPR
+    ]
+
+    // Generate URL with desired transformations
+    const src = cloudinary.url(cloudinaryImage.public_id, {
+      crop: 'scale',
+      fetch_format: 'auto',
+      quality: 'auto',
+      width: 1440,
+    })
+
+    // Generate srcset attribute
+    const srcSet = widths
+      .map(
+        width =>
+          `${cloudinary.url(cloudinaryImage.public_id, {
+            crop: 'scale',
+            fetch_format: 'auto',
+            quality: 'auto',
+            width,
+          })} ${width}w`,
+      )
+      .join(', ')
+
+    const sizes = '(min-width: 768px) 768px, 100vw'
+
+    const metadata: CloudinaryImageMetadata = {
+      alt: alt ?? '',
+      caption: caption ?? '',
+      height,
+      sizes,
+      src,
+      srcSet,
+      width,
+    }
+
+    // Cache the result (dev mode only)
+    await setCached(publicId, metadata, 'cloudinary')
+
+    return Ok(metadata)
+  } catch (error) {
+    console.error('fetchCloudinaryImageMetadata error:', error)
+    return Err(error instanceof Error ? error : new Error(String(error)))
   }
-
-  const alt = (cloudinaryImage.context as CloudinaryImageContext)?.custom.alt // "custom" property currently defined as type "object" by sdk
-
-  if (!alt) {
-    // TODO: restore strictness? I disabled it after a couple "/fetch/" gifs were missing all contextual metadata
-    console.error(`🚨 Cloudinary image "${publicId}" is missing alt text in contextual metadata.`)
-    // throw new Error(`🚨 Cloudinary image "${publicId}" is missing alt text in contextual metadata.`)
-  }
-
-  const caption = (cloudinaryImage.context as CloudinaryImageContext)?.custom.caption // comes from "Title" field in contextual metadata
-
-  const width = cloudinaryImage.width
-  if (typeof width !== 'number') {
-    throw new Error(`🚨 Cloudinary image "${publicId}" is missing width metadata.`)
-  }
-
-  const height = cloudinaryImage.height
-  if (typeof height !== 'number') {
-    throw new Error(`🚨 Cloudinary image "${publicId}" is missing height metadata.`)
-  }
-
-  // console.log(`✅ Fetched Cloudinary image metadata for "${url}"`)
-
-  // TODO: separate into multiple functions: (1) fetch cloudinary image metadata from (2) update image metadata logic
-  const widths = [
-    350, // image layout width on phone at 1x DPR
-    700, // image layout width on phone at 2x DPR
-    850,
-    1020,
-    1200, // image layout width on phone at 3x DPR
-    1440, // max image layout width at 2x DPR (skipped 1x since 700px is already included above)
-    1680,
-    1920,
-    2160, // max image layout width at 3x DPR
-  ]
-
-  // Generate URL with desired transformations
-  const src = cloudinary.url(cloudinaryImage.public_id, {
-    crop: 'scale',
-    fetch_format: 'auto',
-    quality: 'auto',
-    width: 1440,
-  })
-
-  // Generate srcset attribute
-  const srcSet = widths
-    .map(
-      width =>
-        `${cloudinary.url(cloudinaryImage.public_id, {
-          crop: 'scale',
-          fetch_format: 'auto',
-          quality: 'auto',
-          width,
-        })} ${width}w`,
-    )
-    .join(', ')
-
-  const sizes = '(min-width: 768px) 768px, 100vw'
-
-  const metadata: CloudinaryImageMetadata = {
-    alt: alt ?? '',
-    caption: caption ?? '',
-    height,
-    sizes,
-    src,
-    srcSet,
-    width,
-  }
-
-  // Cache the result (dev mode only)
-  await setCached(publicId, metadata, 'cloudinary')
-
-  return metadata
 }

--- a/lib/cloudinary/fetchCloudinaryImageMetadata.ts
+++ b/lib/cloudinary/fetchCloudinaryImageMetadata.ts
@@ -3,7 +3,7 @@ import cloudinary from '@/lib/cloudinary/client'
 import { type CloudinaryResource } from '@/lib/cloudinary/types'
 import { getErrorDetails } from '@/utils/logging'
 import parsePublicIdFromCloudinaryUrl from './parsePublicIdFromCloudinaryUrl'
-import { Ok, Err, type Result } from '@/utils/result'
+import { Ok, toErr, type Result } from '@/utils/result'
 
 export type CloudinaryImageMetadata = {
   alt: string
@@ -129,7 +129,6 @@ export default async function fetchCloudinaryImageMetadata(
 
     return Ok(metadata)
   } catch (error) {
-    console.error('fetchCloudinaryImageMetadata error:', error)
-    return Err(error instanceof Error ? error : new Error(String(error)))
+    return toErr(error, 'fetchCloudinaryImageMetadata')
   }
 }

--- a/lib/itunes/fetchItunesItems.test.ts
+++ b/lib/itunes/fetchItunesItems.test.ts
@@ -1,0 +1,303 @@
+import fetchItunesItems from './fetchItunesItems'
+import { isOk, isErr } from '@/utils/result'
+
+// Mock dependencies
+vi.mock('@/lib/cloudinary/transformCloudinaryImage', () => ({
+  default: vi.fn((url: string) => url), // Return URL unchanged for simplicity
+}))
+
+vi.mock('@/utils/getImagePlaceholderForEnv', () => ({
+  default: vi.fn(async () => 'data:image/png;base64,placeholder'),
+}))
+
+describe('fetchItunesItems', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('success cases', () => {
+    it('returns Ok with valid items from API', async () => {
+      const mockResponse = {
+        results: [
+          {
+            collectionId: 123,
+            collectionViewUrl: 'https://music.apple.com/album/123',
+            artistName: 'Test Artist',
+            artworkUrl100: 'https://example.com/art/100x100bb.jpg',
+          },
+        ],
+      }
+
+      global.fetch = vi.fn(async () => ({
+        json: async () => mockResponse,
+      })) as any
+
+      const inputItems = [{ id: 123, name: 'Test Album', date: '2024-01-15' }]
+
+      const result = await fetchItunesItems(inputItems, 'music', 'album')
+
+      expect(isOk(result)).toBe(true)
+      if (isOk(result)) {
+        expect(result.value).toHaveLength(1)
+        expect(result.value[0]).toMatchObject({
+          id: '123',
+          title: 'Test Album',
+          artist: 'Test Artist',
+          date: '2024-01-15',
+          link: 'https://music.apple.com/album/123',
+        })
+      }
+    })
+
+    it('returns Ok with multiple items sorted by date descending', async () => {
+      const mockResponse = {
+        results: [
+          {
+            collectionId: 1,
+            collectionViewUrl: 'https://music.apple.com/album/1',
+            artistName: 'Artist 1',
+            artworkUrl100: 'https://example.com/art/100x100bb.jpg',
+          },
+          {
+            collectionId: 2,
+            collectionViewUrl: 'https://music.apple.com/album/2',
+            artistName: 'Artist 2',
+            artworkUrl100: 'https://example.com/art/100x100bb.jpg',
+          },
+          {
+            collectionId: 3,
+            collectionViewUrl: 'https://music.apple.com/album/3',
+            artistName: 'Artist 3',
+            artworkUrl100: 'https://example.com/art/100x100bb.jpg',
+          },
+        ],
+      }
+
+      global.fetch = vi.fn(async () => ({
+        json: async () => mockResponse,
+      })) as any
+
+      const inputItems = [
+        { id: 1, name: 'Album 1', date: '2024-01-15' },
+        { id: 2, name: 'Album 2', date: '2024-03-20' }, // Most recent
+        { id: 3, name: 'Album 3', date: '2024-02-10' },
+      ]
+
+      const result = await fetchItunesItems(inputItems, 'music', 'album')
+
+      expect(isOk(result)).toBe(true)
+      if (isOk(result)) {
+        expect(result.value).toHaveLength(3)
+        expect(result.value[0].date).toBe('2024-03-20') // Most recent first
+        expect(result.value[1].date).toBe('2024-02-10')
+        expect(result.value[2].date).toBe('2024-01-15')
+      }
+    })
+
+    it('handles books with trackId and trackViewUrl', async () => {
+      const mockResponse = {
+        results: [
+          {
+            trackId: 456,
+            trackViewUrl: 'https://books.apple.com/book/456',
+            artistName: 'Author Name',
+            artworkUrl100: 'https://example.com/art/100x100bb.jpg',
+          },
+        ],
+      }
+
+      global.fetch = vi.fn(async () => ({
+        json: async () => mockResponse,
+      })) as any
+
+      const inputItems = [{ id: 456, name: 'Test Book', date: '2024-01-15' }]
+
+      const result = await fetchItunesItems(inputItems, 'ebook', 'ebook')
+
+      expect(isOk(result)).toBe(true)
+      if (isOk(result)) {
+        expect(result.value[0].id).toBe('456')
+        expect(result.value[0].link).toBe('https://books.apple.com/book/456')
+      }
+    })
+
+    it('filters out invalid items but returns Ok with valid ones', async () => {
+      const mockResponse = {
+        results: [
+          {
+            collectionId: 1,
+            collectionViewUrl: 'https://music.apple.com/album/1',
+            artistName: 'Valid Artist',
+            artworkUrl100: 'https://example.com/art/100x100bb.jpg',
+          },
+          {
+            // Missing required fields - should be filtered out
+            collectionId: 2,
+            artworkUrl100: 'not-a-url',
+          },
+          {
+            collectionId: 3,
+            collectionViewUrl: 'https://music.apple.com/album/3',
+            artistName: 'Another Valid Artist',
+            artworkUrl100: 'https://example.com/art/100x100bb.jpg',
+          },
+        ],
+      }
+
+      global.fetch = vi.fn(async () => ({
+        json: async () => mockResponse,
+      })) as any
+
+      const inputItems = [
+        { id: 1, name: 'Album 1', date: '2024-01-15' },
+        { id: 2, name: 'Album 2', date: '2024-02-15' },
+        { id: 3, name: 'Album 3', date: '2024-03-15' },
+      ]
+
+      const result = await fetchItunesItems(inputItems, 'music', 'album')
+
+      expect(isOk(result)).toBe(true)
+      if (isOk(result)) {
+        // Should only have 2 valid items (item 2 filtered out)
+        expect(result.value).toHaveLength(2)
+        expect(result.value[0].id).toBe('3')
+        expect(result.value[1].id).toBe('1')
+      }
+    })
+
+    it('skips items not in input list', async () => {
+      const mockResponse = {
+        results: [
+          {
+            collectionId: 1,
+            collectionViewUrl: 'https://music.apple.com/album/1',
+            artistName: 'Artist 1',
+            artworkUrl100: 'https://example.com/art/100x100bb.jpg',
+          },
+          {
+            collectionId: 999, // Not in input items
+            collectionViewUrl: 'https://music.apple.com/album/999',
+            artistName: 'Artist 999',
+            artworkUrl100: 'https://example.com/art/100x100bb.jpg',
+          },
+        ],
+      }
+
+      global.fetch = vi.fn(async () => ({
+        json: async () => mockResponse,
+      })) as any
+
+      const inputItems = [{ id: 1, name: 'Album 1', date: '2024-01-15' }]
+
+      const result = await fetchItunesItems(inputItems, 'music', 'album')
+
+      expect(isOk(result)).toBe(true)
+      if (isOk(result)) {
+        expect(result.value).toHaveLength(1)
+        expect(result.value[0].id).toBe('1')
+      }
+    })
+
+    it('deduplicates items with same ID', async () => {
+      const mockResponse = {
+        results: [
+          {
+            collectionId: 1,
+            collectionViewUrl: 'https://music.apple.com/album/1',
+            artistName: 'Artist 1',
+            artworkUrl100: 'https://example.com/art/100x100bb.jpg',
+          },
+          {
+            collectionId: 1, // Duplicate
+            collectionViewUrl: 'https://music.apple.com/album/1',
+            artistName: 'Artist 1',
+            artworkUrl100: 'https://example.com/art/100x100bb.jpg',
+          },
+        ],
+      }
+
+      global.fetch = vi.fn(async () => ({
+        json: async () => mockResponse,
+      })) as any
+
+      const inputItems = [{ id: 1, name: 'Album 1', date: '2024-01-15' }]
+
+      const result = await fetchItunesItems(inputItems, 'music', 'album')
+
+      expect(isOk(result)).toBe(true)
+      if (isOk(result)) {
+        expect(result.value).toHaveLength(1)
+      }
+    })
+
+    it('returns Ok with empty array when no valid items', async () => {
+      const mockResponse = {
+        results: [],
+      }
+
+      global.fetch = vi.fn(async () => ({
+        json: async () => mockResponse,
+      })) as any
+
+      const inputItems = [{ id: 1, name: 'Album 1', date: '2024-01-15' }]
+
+      const result = await fetchItunesItems(inputItems, 'music', 'album')
+
+      expect(isOk(result)).toBe(true)
+      if (isOk(result)) {
+        expect(result.value).toEqual([])
+      }
+    })
+  })
+
+  describe('error cases', () => {
+    it('returns Err when fetch fails', async () => {
+      const networkError = new Error('Network error')
+      global.fetch = vi.fn(async () => {
+        throw networkError
+      }) as any
+
+      const inputItems = [{ id: 1, name: 'Album 1', date: '2024-01-15' }]
+
+      const result = await fetchItunesItems(inputItems, 'music', 'album')
+
+      expect(isErr(result)).toBe(true)
+      if (isErr(result)) {
+        expect(result.error).toBe(networkError)
+      }
+    })
+
+    it('returns Err when JSON parsing fails', async () => {
+      global.fetch = vi.fn(async () => ({
+        json: async () => {
+          throw new Error('Invalid JSON')
+        },
+      })) as any
+
+      const inputItems = [{ id: 1, name: 'Album 1', date: '2024-01-15' }]
+
+      const result = await fetchItunesItems(inputItems, 'music', 'album')
+
+      expect(isErr(result)).toBe(true)
+      if (isErr(result)) {
+        expect(result.error.message).toBe('Invalid JSON')
+      }
+    })
+
+    it('wraps non-Error exceptions as Error', async () => {
+      global.fetch = vi.fn(async () => {
+        throw 'string error'
+      }) as any
+
+      const inputItems = [{ id: 1, name: 'Album 1', date: '2024-01-15' }]
+
+      const result = await fetchItunesItems(inputItems, 'music', 'album')
+
+      expect(isErr(result)).toBe(true)
+      if (isErr(result)) {
+        expect(result.error).toBeInstanceOf(Error)
+        expect(result.error.message).toBe('string error')
+      }
+    })
+  })
+})

--- a/lib/itunes/fetchItunesItems.ts
+++ b/lib/itunes/fetchItunesItems.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 import transformCloudinaryImage from '@/lib/cloudinary/transformCloudinaryImage'
 import getImagePlaceholderForEnv from '@/utils/getImagePlaceholderForEnv'
-import { type Result, Ok, Err } from '@/utils/result'
+import { type Result, Ok, toErr } from '@/utils/result'
 
 interface iTunesListItem {
   date: string
@@ -128,7 +128,6 @@ export default async function fetchItunesItems(
     const sortedResults = uniqueResults.sort((a, b) => b.date.localeCompare(a.date))
     return Ok(sortedResults)
   } catch (error) {
-    console.error('fetchItunesItems error:', error)
-    return Err(error instanceof Error ? error : new Error(String(error)))
+    return toErr(error, 'fetchItunesItems')
   }
 }

--- a/lib/itunes/fetchItunesItems.ts
+++ b/lib/itunes/fetchItunesItems.ts
@@ -114,15 +114,16 @@ export default async function fetchItunesItems(
 
     // Remove duplicates (keep first occurrence) and nulls
     const seenIds = new Set<string>()
-    const uniqueResults = formattedResults.filter((item) => {
-      if (!item) return false
+    const uniqueResults: iTunesItem[] = []
+    for (const item of formattedResults) {
+      if (!item) continue
       if (seenIds.has(item.id)) {
         console.log('Duplicate iTunes result:', item.id)
-        return false
+        continue
       }
       seenIds.add(item.id)
-      return true
-    })
+      uniqueResults.push(item)
+    }
 
     const sortedResults = uniqueResults.sort((a, b) => b.date.localeCompare(a.date))
     return Ok(sortedResults)

--- a/lib/notion/getBlockChildren.ts
+++ b/lib/notion/getBlockChildren.ts
@@ -1,7 +1,7 @@
 import notion, { collectPaginatedAPI } from './client'
 import { BlockSchema, type Block, type GroupedBlock, type BulletedListBlock, type NumberedListBlock } from './schemas/block'
 import { logValidationError } from '@/utils/zod'
-import { Ok, Err, type Result } from '@/utils/result'
+import { Ok, toErr, type Result } from '@/utils/result'
 
 export const INVALID_BLOCK_ERROR = 'Invalid block data - build aborted'
 
@@ -100,7 +100,6 @@ export default async function getBlockChildren(blockId: string): Promise<Result<
     const blocks = validateBlocks(children)
     return Ok(blocks)
   } catch (error) {
-    console.error('getBlockChildren error:', error)
-    return Err(error instanceof Error ? error : new Error(String(error)))
+    return toErr(error, 'getBlockChildren')
   }
 }

--- a/lib/notion/getBlockChildren.ts
+++ b/lib/notion/getBlockChildren.ts
@@ -1,6 +1,7 @@
 import notion, { collectPaginatedAPI } from './client'
 import { BlockSchema, type Block, type GroupedBlock, type BulletedListBlock, type NumberedListBlock } from './schemas/block'
 import { logValidationError } from '@/utils/zod'
+import { Ok, Err, type Result } from '@/utils/result'
 
 export const INVALID_BLOCK_ERROR = 'Invalid block data - build aborted'
 
@@ -89,11 +90,17 @@ export function validateBlocks(blocks: unknown[]): GroupedBlock[] {
  *
  * @see https://developers.notion.com/reference/get-block-children
  */
-export default async function getBlockChildren(blockId: string): Promise<GroupedBlock[]> {
-  const children = await collectPaginatedAPI(notion.blocks.children.list, {
-    block_id: blockId,
-  })
+export default async function getBlockChildren(blockId: string): Promise<Result<GroupedBlock[], Error>> {
+  try {
+    const children = await collectPaginatedAPI(notion.blocks.children.list, {
+      block_id: blockId,
+    })
 
-  // Validate and transform blocks at API boundary
-  return validateBlocks(children)
+    // Validate and transform blocks at API boundary
+    const blocks = validateBlocks(children)
+    return Ok(blocks)
+  } catch (error) {
+    console.error('getBlockChildren error:', error)
+    return Err(error instanceof Error ? error : new Error(String(error)))
+  }
 }

--- a/lib/notion/getMediaItems.test.ts
+++ b/lib/notion/getMediaItems.test.ts
@@ -1,10 +1,34 @@
-import {
+import getMediaItems, {
   transformNotionPagesToMediaItems,
   INVALID_MEDIA_ITEM_ERROR,
   INVALID_MEDIA_PROPERTIES_ERROR,
   type NotionMediaItem,
 } from './getMediaItems'
 import { createTitleProperty, createNumberProperty, createDateProperty } from './testing/property-factories'
+import { isOk, isErr } from '@/utils/result'
+
+// Mock dependencies
+vi.mock('./client', () => ({
+  default: {
+    dataSources: {
+      query: vi.fn(),
+    },
+  },
+  collectPaginatedAPI: vi.fn(),
+}))
+
+vi.mock('@/lib/cache/filesystem', () => ({
+  getCached: vi.fn(),
+  setCached: vi.fn(),
+}))
+
+vi.mock('@/lib/env', () => ({
+  env: {
+    NOTION_DATA_SOURCE_ID_BOOKS: 'book-ds-id',
+    NOTION_DATA_SOURCE_ID_ALBUMS: 'album-ds-id',
+    NOTION_DATA_SOURCE_ID_PODCASTS: 'podcast-ds-id',
+  },
+}))
 
 describe('transformNotionPagesToMediaItems', () => {
   it('transforms valid Notion pages to media items', () => {
@@ -127,5 +151,205 @@ describe('transformNotionPagesToMediaItems', () => {
     expect(result).toHaveLength(2)
     expect(result[0].name).toBe('Book 1')
     expect(result[1].name).toBe('Book 2')
+  })
+})
+
+describe('getMediaItems', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('success cases', () => {
+    it('returns Ok with valid media items from Notion API', async () => {
+      const { collectPaginatedAPI } = await import('./client')
+      const { getCached, setCached } = await import('@/lib/cache/filesystem')
+
+      vi.mocked(getCached).mockResolvedValue(null)
+      vi.mocked(collectPaginatedAPI).mockResolvedValue([
+        {
+          id: '123',
+          properties: {
+            Title: createTitleProperty('Test Book'),
+            'Apple ID': createNumberProperty(12345),
+            Date: createDateProperty('2024-01-15'),
+          },
+        },
+      ])
+
+      const result = await getMediaItems({ category: 'books' })
+
+      expect(isOk(result)).toBe(true)
+      if (isOk(result)) {
+        expect(result.value).toHaveLength(1)
+        expect(result.value[0]).toMatchObject({
+          id: '123',
+          name: 'Test Book',
+          appleId: 12345,
+          date: '2024-01-15',
+        })
+      }
+
+      expect(setCached).toHaveBeenCalledWith('media-books', expect.any(Array), 'notion')
+    })
+
+    it('returns Ok with cached data when available', async () => {
+      const { collectPaginatedAPI } = await import('./client')
+      const { getCached } = await import('@/lib/cache/filesystem')
+
+      const cachedData: NotionMediaItem[] = [
+        { id: '456', name: 'Cached Book', appleId: 99999, date: '2024-01-01' },
+      ]
+      vi.mocked(getCached).mockResolvedValue(cachedData)
+
+      const result = await getMediaItems({ category: 'books' })
+
+      expect(isOk(result)).toBe(true)
+      if (isOk(result)) {
+        expect(result.value).toEqual(cachedData)
+      }
+
+      // Should not call API when cache hit
+      expect(collectPaginatedAPI).not.toHaveBeenCalled()
+    })
+
+    it('skips cache when skipCache is true', async () => {
+      const { collectPaginatedAPI } = await import('./client')
+      const { getCached, setCached } = await import('@/lib/cache/filesystem')
+
+      vi.mocked(getCached).mockResolvedValue([{ id: 'old', name: 'Old', appleId: 1, date: '2020-01-01' }])
+      vi.mocked(collectPaginatedAPI).mockResolvedValue([
+        {
+          id: '789',
+          properties: {
+            Title: createTitleProperty('Fresh Book'),
+            'Apple ID': createNumberProperty(77777),
+            Date: createDateProperty('2024-03-15'),
+          },
+        },
+      ])
+
+      const result = await getMediaItems({ category: 'books', skipCache: true })
+
+      expect(isOk(result)).toBe(true)
+      if (isOk(result)) {
+        expect(result.value[0].name).toBe('Fresh Book')
+      }
+
+      // Should call API and update cache even with skipCache
+      expect(collectPaginatedAPI).toHaveBeenCalled()
+      expect(setCached).toHaveBeenCalled()
+    })
+
+    it('handles different media categories', async () => {
+      const { collectPaginatedAPI } = await import('./client')
+      const { getCached } = await import('@/lib/cache/filesystem')
+
+      vi.mocked(getCached).mockResolvedValue(null)
+      vi.mocked(collectPaginatedAPI).mockResolvedValue([
+        {
+          id: 'album-1',
+          properties: {
+            Title: createTitleProperty('Test Album'),
+            'Apple ID': createNumberProperty(11111),
+            Date: createDateProperty('2024-02-20'),
+          },
+        },
+      ])
+
+      const result = await getMediaItems({ category: 'albums' })
+
+      expect(isOk(result)).toBe(true)
+      if (isOk(result)) {
+        expect(result.value).toHaveLength(1)
+        expect(result.value[0].name).toBe('Test Album')
+      }
+    })
+
+    it('returns Ok with empty array when no items', async () => {
+      const { collectPaginatedAPI } = await import('./client')
+      const { getCached } = await import('@/lib/cache/filesystem')
+
+      vi.mocked(getCached).mockResolvedValue(null)
+      vi.mocked(collectPaginatedAPI).mockResolvedValue([])
+
+      const result = await getMediaItems({ category: 'podcasts' })
+
+      expect(isOk(result)).toBe(true)
+      if (isOk(result)) {
+        expect(result.value).toEqual([])
+      }
+    })
+  })
+
+  describe('error cases', () => {
+    it('returns Err when Notion API call fails', async () => {
+      const { collectPaginatedAPI } = await import('./client')
+      const { getCached } = await import('@/lib/cache/filesystem')
+
+      vi.mocked(getCached).mockResolvedValue(null)
+      const apiError = new Error('Notion API error')
+      vi.mocked(collectPaginatedAPI).mockRejectedValue(apiError)
+
+      const result = await getMediaItems({ category: 'books' })
+
+      expect(isErr(result)).toBe(true)
+      if (isErr(result)) {
+        expect(result.error).toBe(apiError)
+      }
+    })
+
+    it('returns Err when validation fails', async () => {
+      const { collectPaginatedAPI } = await import('./client')
+      const { getCached } = await import('@/lib/cache/filesystem')
+
+      vi.mocked(getCached).mockResolvedValue(null)
+      vi.mocked(collectPaginatedAPI).mockResolvedValue([
+        {
+          id: '123',
+          properties: {
+            Title: createTitleProperty('Book'),
+            'Apple ID': createNumberProperty(-999), // Invalid: negative
+            Date: createDateProperty('2024-01-15'),
+          },
+        },
+      ])
+
+      const result = await getMediaItems({ category: 'books' })
+
+      expect(isErr(result)).toBe(true)
+      if (isErr(result)) {
+        expect(result.error.message).toBe(INVALID_MEDIA_ITEM_ERROR.books)
+      }
+    })
+
+    it('returns Err when cache read fails', async () => {
+      const { getCached } = await import('@/lib/cache/filesystem')
+
+      const cacheError = new Error('Cache read error')
+      vi.mocked(getCached).mockRejectedValue(cacheError)
+
+      const result = await getMediaItems({ category: 'books' })
+
+      expect(isErr(result)).toBe(true)
+      if (isErr(result)) {
+        expect(result.error).toBe(cacheError)
+      }
+    })
+
+    it('wraps non-Error exceptions as Error', async () => {
+      const { collectPaginatedAPI } = await import('./client')
+      const { getCached } = await import('@/lib/cache/filesystem')
+
+      vi.mocked(getCached).mockResolvedValue(null)
+      vi.mocked(collectPaginatedAPI).mockRejectedValue('string error')
+
+      const result = await getMediaItems({ category: 'books' })
+
+      expect(isErr(result)).toBe(true)
+      if (isErr(result)) {
+        expect(result.error).toBeInstanceOf(Error)
+        expect(result.error.message).toBe('string error')
+      }
+    })
   })
 })

--- a/lib/notion/getMediaItems.ts
+++ b/lib/notion/getMediaItems.ts
@@ -10,7 +10,7 @@ import {
 import { PageMetadataSchema } from './schemas/page'
 import { logValidationError } from '@/utils/zod'
 import { env } from '@/lib/env'
-import { type Result, Ok, Err } from '@/utils/result'
+import { type Result, Ok, toErr } from '@/utils/result'
 
 type MediaCategory = 'books' | 'albums' | 'podcasts'
 
@@ -144,7 +144,6 @@ export default async function getMediaItems(options: Options): Promise<Result<No
 
     return Ok(items)
   } catch (error) {
-    console.error(`getMediaItems error (${category}):`, error)
-    return Err(error instanceof Error ? error : new Error(String(error)))
+    return toErr(error, `getMediaItems (${category})`)
   }
 }

--- a/lib/notion/getPost.test.ts
+++ b/lib/notion/getPost.test.ts
@@ -1,10 +1,40 @@
-import { transformNotionPageToPost, INVALID_POST_DETAILS_ERROR, INVALID_POST_PROPERTIES_ERROR } from './getPost'
+import getPost, { transformNotionPageToPost, INVALID_POST_DETAILS_ERROR, INVALID_POST_PROPERTIES_ERROR } from './getPost'
 import {
   createRichTextProperty,
   createTitleProperty,
   createDateProperty,
   createFilesProperty,
 } from './testing/property-factories'
+import { isOk, isErr } from '@/utils/result'
+import type { Post } from './schemas/post'
+
+// Mock dependencies
+vi.mock('./client', () => ({
+  default: {
+    dataSources: {
+      query: vi.fn(),
+    },
+  },
+}))
+
+vi.mock('@/lib/cache/filesystem', () => ({
+  getCached: vi.fn(),
+  setCached: vi.fn(),
+}))
+
+vi.mock('./getBlockChildren', () => ({
+  default: vi.fn(),
+}))
+
+vi.mock('./getPosts', () => ({
+  default: vi.fn(),
+}))
+
+vi.mock('@/lib/env', () => ({
+  env: {
+    NOTION_DATA_SOURCE_ID_WRITING: 'writing-ds-id',
+  },
+}))
 
 describe('transformNotionPageToPost', () => {
   it('transforms valid Notion page to post', () => {
@@ -149,5 +179,373 @@ describe('transformNotionPageToPost', () => {
     }
 
     expect(() => transformNotionPageToPost(page)).toThrow(expectedError || INVALID_POST_DETAILS_ERROR)
+  })
+})
+
+describe('getPost', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('success cases', () => {
+    it('returns Ok(null) when slug is null', async () => {
+      const result = await getPost({ slug: null })
+
+      expect(isOk(result)).toBe(true)
+      if (isOk(result)) {
+        expect(result.value).toBeNull()
+      }
+    })
+
+    it('returns Ok(null) when slug is empty string', async () => {
+      const result = await getPost({ slug: '' })
+
+      expect(isOk(result)).toBe(true)
+      if (isOk(result)) {
+        expect(result.value).toBeNull()
+      }
+    })
+
+    it('returns Ok with cached post when available', async () => {
+      const { getCached } = await import('@/lib/cache/filesystem')
+
+      const cachedPost: Post = {
+        id: '456',
+        slug: 'cached-post',
+        title: 'Cached Post',
+        description: null,
+        firstPublished: '2024-01-01',
+        featuredImage: null,
+        lastEditedTime: '2024-01-01T00:00:00.000Z',
+        blocks: [],
+        prevPost: null,
+        nextPost: null,
+      }
+      vi.mocked(getCached).mockResolvedValue(cachedPost)
+
+      const result = await getPost({ slug: 'cached-post' })
+
+      expect(isOk(result)).toBe(true)
+      if (isOk(result)) {
+        expect(result.value).toEqual(cachedPost)
+      }
+    })
+
+    it('returns Ok with post from Notion API', async () => {
+      const notion = (await import('./client')).default
+      const { getCached, setCached } = await import('@/lib/cache/filesystem')
+
+      vi.mocked(getCached).mockResolvedValue(null)
+      vi.mocked(notion.dataSources.query).mockResolvedValue({
+        results: [
+          {
+            id: '123',
+            last_edited_time: '2024-01-20T10:30:00.000Z',
+            properties: {
+              Slug: createRichTextProperty('test-post'),
+              Title: createTitleProperty('Test Post'),
+              Description: createRichTextProperty('A test'),
+              'First published': createDateProperty('2024-01-15'),
+              'Featured image': createFilesProperty([]),
+            },
+          },
+        ],
+      } as any)
+
+      const result = await getPost({ slug: 'test-post' })
+
+      expect(isOk(result)).toBe(true)
+      if (isOk(result)) {
+        expect(result.value).toMatchObject({
+          id: '123',
+          slug: 'test-post',
+          title: 'Test Post',
+          description: 'A test',
+          firstPublished: '2024-01-15',
+        })
+      }
+
+      expect(setCached).toHaveBeenCalledWith(
+        'post-test-post-blocks-false-nav-false',
+        expect.any(Object),
+        'notion'
+      )
+    })
+
+    it('returns Ok(null) when post not found', async () => {
+      const notion = (await import('./client')).default
+      const { getCached } = await import('@/lib/cache/filesystem')
+
+      vi.mocked(getCached).mockResolvedValue(null)
+      vi.mocked(notion.dataSources.query).mockResolvedValue({
+        results: [],
+      } as any)
+
+      const result = await getPost({ slug: 'nonexistent' })
+
+      expect(isOk(result)).toBe(true)
+      if (isOk(result)) {
+        expect(result.value).toBeNull()
+      }
+    })
+
+    it('skips cache when skipCache is true', async () => {
+      const notion = (await import('./client')).default
+      const { getCached, setCached } = await import('@/lib/cache/filesystem')
+
+      vi.mocked(getCached).mockResolvedValue({ id: 'old' } as any)
+      vi.mocked(notion.dataSources.query).mockResolvedValue({
+        results: [
+          {
+            id: '789',
+            last_edited_time: '2024-03-15T12:00:00.000Z',
+            properties: {
+              Slug: createRichTextProperty('fresh-post'),
+              Title: createTitleProperty('Fresh Post'),
+              Description: createRichTextProperty(null),
+              'First published': createDateProperty('2024-03-15'),
+              'Featured image': createFilesProperty([]),
+            },
+          },
+        ],
+      } as any)
+
+      const result = await getPost({ slug: 'fresh-post', skipCache: true })
+
+      expect(isOk(result)).toBe(true)
+      if (isOk(result)) {
+        expect(result.value?.slug).toBe('fresh-post')
+      }
+
+      expect(getCached).not.toHaveBeenCalled()
+      expect(setCached).toHaveBeenCalled()
+    })
+
+    it('includes blocks when includeBlocks is true', async () => {
+      const notion = (await import('./client')).default
+      const { getCached } = await import('@/lib/cache/filesystem')
+      const getBlockChildren = (await import('./getBlockChildren')).default
+
+      vi.mocked(getCached).mockResolvedValue(null)
+      vi.mocked(notion.dataSources.query).mockResolvedValue({
+        results: [
+          {
+            id: '123',
+            last_edited_time: '2024-01-20T10:30:00.000Z',
+            properties: {
+              Slug: createRichTextProperty('post-with-blocks'),
+              Title: createTitleProperty('Post with Blocks'),
+              Description: createRichTextProperty(null),
+              'First published': createDateProperty('2024-01-15'),
+              'Featured image': createFilesProperty([]),
+            },
+          },
+        ],
+      } as any)
+
+      const mockBlocks = [{ id: 'block-1', type: 'paragraph' }]
+      vi.mocked(getBlockChildren).mockResolvedValue(mockBlocks as any)
+
+      const result = await getPost({ slug: 'post-with-blocks', includeBlocks: true })
+
+      expect(isOk(result)).toBe(true)
+      if (isOk(result)) {
+        expect(result.value?.blocks).toEqual(mockBlocks)
+      }
+
+      expect(getBlockChildren).toHaveBeenCalledWith('123')
+    })
+
+    it('includes prev/next navigation when includePrevAndNext is true', async () => {
+      const notion = (await import('./client')).default
+      const { getCached } = await import('@/lib/cache/filesystem')
+      const getPosts = (await import('./getPosts')).default
+      const { Ok } = await import('@/utils/result')
+
+      vi.mocked(getCached).mockResolvedValue(null)
+      vi.mocked(notion.dataSources.query).mockResolvedValue({
+        results: [
+          {
+            id: '222',
+            last_edited_time: '2024-02-15T10:00:00.000Z',
+            properties: {
+              Slug: createRichTextProperty('middle-post'),
+              Title: createTitleProperty('Middle Post'),
+              Description: createRichTextProperty(null),
+              'First published': createDateProperty('2024-02-15'),
+              'Featured image': createFilesProperty([]),
+            },
+          },
+        ],
+      } as any)
+
+      const mockPosts = [
+        {
+          id: '111',
+          slug: 'first-post',
+          title: 'First Post',
+          description: null,
+          firstPublished: '2024-01-01',
+          featuredImage: null,
+        },
+        {
+          id: '222',
+          slug: 'middle-post',
+          title: 'Middle Post',
+          description: null,
+          firstPublished: '2024-02-15',
+          featuredImage: null,
+        },
+        {
+          id: '333',
+          slug: 'last-post',
+          title: 'Last Post',
+          description: null,
+          firstPublished: '2024-03-01',
+          featuredImage: null,
+        },
+      ]
+      vi.mocked(getPosts).mockResolvedValue(Ok(mockPosts))
+
+      const result = await getPost({ slug: 'middle-post', includePrevAndNext: true })
+
+      expect(isOk(result)).toBe(true)
+      if (isOk(result)) {
+        expect(result.value?.prevPost).toMatchObject({ slug: 'first-post' })
+        expect(result.value?.nextPost).toMatchObject({ slug: 'last-post' })
+      }
+    })
+
+    it('uses correct cache keys for different options', async () => {
+      const { getCached } = await import('@/lib/cache/filesystem')
+
+      vi.mocked(getCached).mockResolvedValue(null)
+
+      await getPost({ slug: 'test' })
+      expect(getCached).toHaveBeenCalledWith('post-test-blocks-false-nav-false', 'notion')
+
+      await getPost({ slug: 'test', includeBlocks: true })
+      expect(getCached).toHaveBeenCalledWith('post-test-blocks-true-nav-false', 'notion')
+
+      await getPost({ slug: 'test', includePrevAndNext: true })
+      expect(getCached).toHaveBeenCalledWith('post-test-blocks-false-nav-true', 'notion')
+    })
+  })
+
+  describe('error cases', () => {
+    it('returns Err when Notion API call fails', async () => {
+      const notion = (await import('./client')).default
+      const { getCached } = await import('@/lib/cache/filesystem')
+
+      vi.mocked(getCached).mockResolvedValue(null)
+      const apiError = new Error('Notion API error')
+      vi.mocked(notion.dataSources.query).mockRejectedValue(apiError)
+
+      const result = await getPost({ slug: 'failing-post' })
+
+      expect(isErr(result)).toBe(true)
+      if (isErr(result)) {
+        expect(result.error).toBe(apiError)
+      }
+    })
+
+    it('returns Err when multiple posts found for slug', async () => {
+      const notion = (await import('./client')).default
+      const { getCached } = await import('@/lib/cache/filesystem')
+
+      vi.mocked(getCached).mockResolvedValue(null)
+      vi.mocked(notion.dataSources.query).mockResolvedValue({
+        results: [
+          {
+            id: '123',
+            last_edited_time: '2024-01-20T10:30:00.000Z',
+            properties: {
+              Slug: createRichTextProperty('duplicate'),
+              Title: createTitleProperty('Post 1'),
+              Description: createRichTextProperty(null),
+              'First published': createDateProperty('2024-01-15'),
+              'Featured image': createFilesProperty([]),
+            },
+          },
+          {
+            id: '456',
+            last_edited_time: '2024-01-21T10:30:00.000Z',
+            properties: {
+              Slug: createRichTextProperty('duplicate'),
+              Title: createTitleProperty('Post 2'),
+              Description: createRichTextProperty(null),
+              'First published': createDateProperty('2024-01-16'),
+              'Featured image': createFilesProperty([]),
+            },
+          },
+        ],
+      } as any)
+
+      const result = await getPost({ slug: 'duplicate' })
+
+      expect(isErr(result)).toBe(true)
+      if (isErr(result)) {
+        expect(result.error.message).toContain('Multiple posts found for slug')
+      }
+    })
+
+    it('returns Err when validation fails', async () => {
+      const notion = (await import('./client')).default
+      const { getCached } = await import('@/lib/cache/filesystem')
+
+      vi.mocked(getCached).mockResolvedValue(null)
+      vi.mocked(notion.dataSources.query).mockResolvedValue({
+        results: [
+          {
+            id: '123',
+            last_edited_time: '2024-01-20T10:30:00.000Z',
+            properties: {
+              Slug: createRichTextProperty(null), // Invalid: missing slug
+              Title: createTitleProperty('Post'),
+              Description: createRichTextProperty(null),
+              'First published': createDateProperty('2024-01-15'),
+              'Featured image': createFilesProperty([]),
+            },
+          },
+        ],
+      } as any)
+
+      const result = await getPost({ slug: 'invalid' })
+
+      expect(isErr(result)).toBe(true)
+      if (isErr(result)) {
+        expect(result.error.message).toBe(INVALID_POST_DETAILS_ERROR)
+      }
+    })
+
+    it('returns Err when cache read fails', async () => {
+      const { getCached } = await import('@/lib/cache/filesystem')
+
+      const cacheError = new Error('Cache read error')
+      vi.mocked(getCached).mockRejectedValue(cacheError)
+
+      const result = await getPost({ slug: 'test' })
+
+      expect(isErr(result)).toBe(true)
+      if (isErr(result)) {
+        expect(result.error).toBe(cacheError)
+      }
+    })
+
+    it('wraps non-Error exceptions as Error', async () => {
+      const notion = (await import('./client')).default
+      const { getCached } = await import('@/lib/cache/filesystem')
+
+      vi.mocked(getCached).mockResolvedValue(null)
+      vi.mocked(notion.dataSources.query).mockRejectedValue('string error')
+
+      const result = await getPost({ slug: 'test' })
+
+      expect(isErr(result)).toBe(true)
+      if (isErr(result)) {
+        expect(result.error).toBeInstanceOf(Error)
+        expect(result.error.message).toBe('string error')
+      }
+    })
   })
 })

--- a/lib/notion/getPost.test.ts
+++ b/lib/notion/getPost.test.ts
@@ -325,6 +325,7 @@ describe('getPost', () => {
       const notion = (await import('./client')).default
       const { getCached } = await import('@/lib/cache/filesystem')
       const getBlockChildren = (await import('./getBlockChildren')).default
+      const { Ok } = await import('@/utils/result')
 
       vi.mocked(getCached).mockResolvedValue(null)
       vi.mocked(notion.dataSources.query).mockResolvedValue({
@@ -344,7 +345,7 @@ describe('getPost', () => {
       } as any)
 
       const mockBlocks = [{ id: 'block-1', type: 'paragraph' }]
-      vi.mocked(getBlockChildren).mockResolvedValue(mockBlocks as any)
+      vi.mocked(getBlockChildren).mockResolvedValue(Ok(mockBlocks as any))
 
       const result = await getPost({ slug: 'post-with-blocks', includeBlocks: true })
 

--- a/lib/notion/getPost.ts
+++ b/lib/notion/getPost.ts
@@ -6,6 +6,7 @@ import { PostListItemSchema, PostPropertiesSchema, type Post, type PostListItem 
 import { PageMetadataSchema } from './schemas/page'
 import { logValidationError } from '@/utils/zod'
 import { env } from '@/lib/env'
+import { unwrap } from '@/utils/result'
 
 type Options = {
   slug: string | null
@@ -119,7 +120,7 @@ export default async function getPost({
   let post = transformNotionPageToPost(response.results[0])
 
   if (includePrevAndNext) {
-    const posts = await getPosts({ sortDirection: 'ascending', skipCache })
+    const posts = unwrap(await getPosts({ sortDirection: 'ascending', skipCache }))
 
     const postSlugs = posts.map(post => post.slug)
     const index = postSlugs.indexOf(slug)

--- a/lib/notion/getPost.ts
+++ b/lib/notion/getPost.ts
@@ -6,7 +6,6 @@ import { PostListItemSchema, PostPropertiesSchema, type Post, type PostListItem 
 import { PageMetadataSchema } from './schemas/page'
 import { logValidationError } from '@/utils/zod'
 import { env } from '@/lib/env'
-import { unwrap } from '@/utils/result'
 
 type Options = {
   slug: string | null
@@ -120,7 +119,7 @@ export default async function getPost({
   let post = transformNotionPageToPost(response.results[0])
 
   if (includePrevAndNext) {
-    const posts = unwrap(await getPosts({ sortDirection: 'ascending', skipCache }))
+    const posts = (await getPosts({ sortDirection: 'ascending', skipCache })).unwrap()
 
     const postSlugs = posts.map(post => post.slug)
     const index = postSlugs.indexOf(slug)

--- a/lib/notion/getPost.ts
+++ b/lib/notion/getPost.ts
@@ -121,8 +121,12 @@ export default async function getPost({
     let post = transformNotionPageToPost(response.results[0])
 
     if (includePrevAndNext) {
-      const posts = (await getPosts({ sortDirection: 'ascending', skipCache })).unwrap()
+      const postsResult = await getPosts({ sortDirection: 'ascending', skipCache })
+      if (!postsResult.ok) {
+        return Err(postsResult.error)
+      }
 
+      const posts = postsResult.value
       const postSlugs = posts.map(post => post.slug)
       const index = postSlugs.indexOf(slug)
 
@@ -134,9 +138,12 @@ export default async function getPost({
     }
 
     if (includeBlocks) {
-      const blocks = (await getBlockChildren(post.id)).unwrap()
+      const blocksResult = await getBlockChildren(post.id)
+      if (!blocksResult.ok) {
+        return Err(blocksResult.error)
+      }
 
-      post = { ...post, blocks }
+      post = { ...post, blocks: blocksResult.value }
     }
 
     // Cache the result (always caches, even when skipCache=true)

--- a/lib/notion/getPost.ts
+++ b/lib/notion/getPost.ts
@@ -134,7 +134,7 @@ export default async function getPost({
     }
 
     if (includeBlocks) {
-      const blocks = await getBlockChildren(post.id)
+      const blocks = (await getBlockChildren(post.id)).unwrap()
 
       post = { ...post, blocks }
     }

--- a/lib/notion/getPost.ts
+++ b/lib/notion/getPost.ts
@@ -6,7 +6,7 @@ import { PostListItemSchema, PostPropertiesSchema, type Post, type PostListItem 
 import { PageMetadataSchema } from './schemas/page'
 import { logValidationError } from '@/utils/zod'
 import { env } from '@/lib/env'
-import { Ok, Err, type Result } from '@/utils/result'
+import { Ok, Err, toErr, type Result } from '@/utils/result'
 
 type Options = {
   slug: string | null
@@ -152,7 +152,6 @@ export default async function getPost({
 
     return Ok(post)
   } catch (error) {
-    console.error('getPost error:', error)
-    return Err(error instanceof Error ? error : new Error(String(error)))
+    return toErr(error, 'getPost')
   }
 }

--- a/lib/notion/getPosts.ts
+++ b/lib/notion/getPosts.ts
@@ -4,7 +4,7 @@ import { PostListItemSchema, PostPropertiesSchema, type PostListItem } from './s
 import { PageMetadataSchema } from './schemas/page'
 import { logValidationError } from '@/utils/zod'
 import { env } from '@/lib/env'
-import { type Result, Ok, Err } from '@/utils/result'
+import { type Result, Ok, toErr } from '@/utils/result'
 
 type Options = {
   sortDirection?: 'ascending' | 'descending'
@@ -106,7 +106,6 @@ export default async function getPosts(options: Options = {}): Promise<Result<Po
 
     return Ok(posts)
   } catch (error) {
-    console.error('getPosts error:', error)
-    return Err(error instanceof Error ? error : new Error(String(error)))
+    return toErr(error, 'getPosts')
   }
 }

--- a/lib/notion/getPosts.ts
+++ b/lib/notion/getPosts.ts
@@ -4,6 +4,7 @@ import { PostListItemSchema, PostPropertiesSchema, type PostListItem } from './s
 import { PageMetadataSchema } from './schemas/page'
 import { logValidationError } from '@/utils/zod'
 import { env } from '@/lib/env'
+import { type Result, Ok, Err } from '@/utils/result'
 
 type Options = {
   sortDirection?: 'ascending' | 'descending'
@@ -64,43 +65,48 @@ export function transformNotionPagesToPostListItems(pages: unknown[]): PostListI
  * @see https://developers.notion.com/reference/query-a-data-source
  * @see https://developers.notion.com/reference/filter-data-source-entries
  */
-export default async function getPosts(options: Options = {}): Promise<PostListItem[]> {
+export default async function getPosts(options: Options = {}): Promise<Result<PostListItem[], Error>> {
   const { sortDirection = 'ascending', skipCache = false } = options
 
-  // Check cache first (cache utility handles dev mode check)
-  const cacheKey = `posts-list-${sortDirection}`
-  if (!skipCache) {
-    const cached = await getCached<PostListItem[]>(cacheKey, 'notion')
-    if (cached) {
-      return cached
+  try {
+    // Check cache first (cache utility handles dev mode check)
+    const cacheKey = `posts-list-${sortDirection}`
+    if (!skipCache) {
+      const cached = await getCached<PostListItem[]>(cacheKey, 'notion')
+      if (cached) {
+        return Ok(cached)
+      }
     }
+
+    console.log(`📥 Fetching posts from Notion API`)
+
+    const pages = await collectPaginatedAPI(notion.dataSources.query, {
+      data_source_id: env.NOTION_DATA_SOURCE_ID_WRITING,
+      filter: {
+        and: [
+          { property: 'Destination', multi_select: { contains: 'blog' } },
+          { property: 'Status', status: { equals: 'Published' } }, // redundant if "First published" also used?
+          { property: 'Title', title: { is_not_empty: true } },
+          { property: 'Slug', rich_text: { is_not_empty: true } },
+          { property: 'Description', rich_text: { is_not_empty: true } },
+          // NOTE: link posts don't have featured images atm
+          // { property: 'Featured image', url: { is_not_empty: true } },
+          { property: 'First published', date: { on_or_before: new Date().toISOString() } },
+        ],
+      },
+      sorts: [{ property: 'First published', direction: sortDirection }],
+    })
+
+    // Transform and validate external data at boundary
+    const posts = transformNotionPagesToPostListItems(pages)
+
+    // Cache the result (always caches, even when skipCache=true)
+    // This ensures ?nocache=true refreshes the cache with latest data
+    await setCached(cacheKey, posts, 'notion')
+
+    return Ok(posts)
+  } catch (error) {
+    console.error('getPosts error:', error)
+    return Err(error instanceof Error ? error : new Error(String(error)))
   }
-
-  console.log(`📥 Fetching posts from Notion API`)
-
-  const pages = await collectPaginatedAPI(notion.dataSources.query, {
-    data_source_id: env.NOTION_DATA_SOURCE_ID_WRITING,
-    filter: {
-      and: [
-        { property: 'Destination', multi_select: { contains: 'blog' } },
-        { property: 'Status', status: { equals: 'Published' } }, // redundant if "First published" also used?
-        { property: 'Title', title: { is_not_empty: true } },
-        { property: 'Slug', rich_text: { is_not_empty: true } },
-        { property: 'Description', rich_text: { is_not_empty: true } },
-        // NOTE: link posts don't have featured images atm
-        // { property: 'Featured image', url: { is_not_empty: true } },
-        { property: 'First published', date: { on_or_before: new Date().toISOString() } },
-      ],
-    },
-    sorts: [{ property: 'First published', direction: sortDirection }],
-  })
-
-  // Transform and validate external data at boundary
-  const posts = transformNotionPagesToPostListItems(pages)
-
-  // Cache the result (always caches, even when skipCache=true)
-  // This ensures ?nocache=true refreshes the cache with latest data
-  await setCached(cacheKey, posts, 'notion')
-
-  return posts
 }

--- a/lib/notion/integration.test.ts
+++ b/lib/notion/integration.test.ts
@@ -1,0 +1,379 @@
+import getPost from './getPost'
+import getPosts from './getPosts'
+import getBlockChildren from './getBlockChildren'
+import getMediaItems from './getMediaItems'
+import { isOk, isErr } from '@/utils/result'
+
+/**
+ * Integration tests for Notion API functions.
+ *
+ * Unlike unit tests that mock everything, these tests verify the full flow:
+ * - Result pattern propagates correctly through nested calls
+ * - Transformations work end-to-end
+ * - Error handling at boundaries between functions
+ *
+ * We still mock the Notion API itself to avoid hitting real endpoints,
+ * but we don't mock our own Result-returning functions.
+ */
+
+// Mock only the Notion client, not our functions
+vi.mock('./client', () => ({
+  default: {
+    dataSources: {
+      query: vi.fn(),
+    },
+    blocks: {
+      children: {
+        list: vi.fn(),
+      },
+    },
+  },
+  collectPaginatedAPI: vi.fn(),
+}))
+
+// Mock cache to avoid filesystem I/O
+vi.mock('@/lib/cache/filesystem', () => ({
+  getCached: vi.fn().mockResolvedValue(null),
+  setCached: vi.fn().mockResolvedValue(undefined),
+}))
+
+describe('Notion API Integration Tests', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    vi.resetAllMocks()
+
+    // Reset mocks to default implementations
+    const notion = (await import('./client')).default
+    const { collectPaginatedAPI } = await import('./client')
+
+    vi.mocked(notion.dataSources.query).mockReset()
+    vi.mocked(collectPaginatedAPI).mockReset()
+  })
+
+  describe('getPost with nested Result calls', () => {
+    it('successfully chains getPosts and getBlockChildren', async () => {
+      const notion = (await import('./client')).default
+      const { collectPaginatedAPI } = await import('./client')
+
+      // Mock getPosts data (will be called for navigation)
+      const mockPostsPages = [
+        {
+          id: 'post-1',
+          last_edited_time: '2024-01-01T00:00:00.000Z',
+          properties: {
+            Slug: { type: 'rich_text', rich_text: [{ plain_text: 'first-post' }] },
+            Title: { type: 'title', title: [{ plain_text: 'First Post' }] },
+            Description: { type: 'rich_text', rich_text: [{ plain_text: 'First description' }] },
+            'First published': { type: 'date', date: { start: '2024-01-01' } },
+            'Featured image': { type: 'files', files: [] },
+          },
+        },
+        {
+          id: 'post-2',
+          last_edited_time: '2024-01-15T00:00:00.000Z',
+          properties: {
+            Slug: { type: 'rich_text', rich_text: [{ plain_text: 'current-post' }] },
+            Title: { type: 'title', title: [{ plain_text: 'Current Post' }] },
+            Description: { type: 'rich_text', rich_text: [{ plain_text: 'Current description' }] },
+            'First published': { type: 'date', date: { start: '2024-01-15' } },
+            'Featured image': { type: 'files', files: [] },
+          },
+        },
+        {
+          id: 'post-3',
+          last_edited_time: '2024-02-01T00:00:00.000Z',
+          properties: {
+            Slug: { type: 'rich_text', rich_text: [{ plain_text: 'next-post' }] },
+            Title: { type: 'title', title: [{ plain_text: 'Next Post' }] },
+            Description: { type: 'rich_text', rich_text: [{ plain_text: 'Next description' }] },
+            'First published': { type: 'date', date: { start: '2024-02-01' } },
+            'Featured image': { type: 'files', files: [] },
+          },
+        },
+      ]
+
+      // Mock getPost query (single post)
+      const mockCurrentPost = mockPostsPages[1]
+
+      // Mock getBlockChildren data
+      const mockBlocks = [
+        {
+          id: 'block-1',
+          type: 'paragraph',
+          paragraph: {
+            rich_text: [
+              {
+                type: 'text',
+                text: { content: 'Test paragraph', link: null },
+                annotations: {
+                  bold: false,
+                  italic: false,
+                  strikethrough: false,
+                  underline: false,
+                  code: false,
+                },
+              },
+            ],
+          },
+        },
+      ]
+
+      // Mock notion.dataSources.query for getPost's direct query
+      vi.mocked(notion.dataSources.query).mockResolvedValueOnce({
+        results: [mockCurrentPost],
+      } as any)
+
+      // Mock collectPaginatedAPI for getPosts (navigation)
+      vi.mocked(collectPaginatedAPI).mockResolvedValueOnce(mockPostsPages as any)
+
+      // Mock collectPaginatedAPI for getBlockChildren
+      vi.mocked(collectPaginatedAPI).mockResolvedValueOnce(mockBlocks as any)
+
+      // Call getPost with both navigation and blocks
+      const result = await getPost({
+        slug: 'current-post',
+        includeBlocks: true,
+        includePrevAndNext: true,
+        skipCache: true,
+      })
+
+      // Verify success
+      expect(isOk(result)).toBe(true)
+      if (!isOk(result)) return
+
+      const post = result.value
+      expect(post).not.toBeNull()
+      if (!post) return
+
+      // Verify post data
+      expect(post.slug).toBe('current-post')
+      expect(post.title).toBe('Current Post')
+
+      // Verify navigation was populated from getPosts
+      expect(post.prevPost).not.toBeNull()
+      expect(post.prevPost?.slug).toBe('first-post')
+      expect(post.nextPost).not.toBeNull()
+      expect(post.nextPost?.slug).toBe('next-post')
+
+      // Verify blocks were populated from getBlockChildren
+      expect(post.blocks).toHaveLength(1)
+      expect(post.blocks[0].type).toBe('paragraph')
+    })
+
+    it('propagates error from getPosts when fetching navigation', async () => {
+      const notion = (await import('./client')).default
+      const { collectPaginatedAPI } = await import('./client')
+
+      // Mock successful getPost query
+      const mockPost = {
+        id: 'post-1',
+        last_edited_time: '2024-01-15T00:00:00.000Z',
+        properties: {
+          Slug: { type: 'rich_text', rich_text: [{ plain_text: 'test-post' }] },
+          Title: { type: 'title', title: [{ plain_text: 'Test Post' }] },
+          Description: { type: 'rich_text', rich_text: [{ plain_text: 'Description' }] },
+          'First published': { type: 'date', date: { start: '2024-01-15' } },
+          'Featured image': { type: 'files', files: [] },
+        },
+      }
+
+      // Mock successful getPost direct query
+      vi.mocked(notion.dataSources.query).mockResolvedValueOnce({
+        results: [mockPost],
+      } as any)
+
+      // Mock getPosts failure (via collectPaginatedAPI)
+      vi.mocked(collectPaginatedAPI).mockRejectedValueOnce(new Error('Failed to fetch posts for navigation'))
+
+      const result = await getPost({
+        slug: 'test-post',
+        includePrevAndNext: true,
+        skipCache: true,
+      })
+
+      // Verify error propagated
+      expect(isErr(result)).toBe(true)
+      if (isErr(result)) {
+        expect(result.error.message).toContain('Failed to fetch posts for navigation')
+      }
+    })
+
+    it('propagates error from getBlockChildren when fetching blocks', async () => {
+      const notion = (await import('./client')).default
+      const { collectPaginatedAPI } = await import('./client')
+
+      // Mock successful getPost query
+      const mockPost = {
+        id: 'post-1',
+        last_edited_time: '2024-01-15T00:00:00.000Z',
+        properties: {
+          Slug: { type: 'rich_text', rich_text: [{ plain_text: 'test-post' }] },
+          Title: { type: 'title', title: [{ plain_text: 'Test Post' }] },
+          Description: { type: 'rich_text', rich_text: [{ plain_text: 'Description' }] },
+          'First published': { type: 'date', date: { start: '2024-01-15' } },
+          'Featured image': { type: 'files', files: [] },
+        },
+      }
+
+      vi.mocked(notion.dataSources.query).mockResolvedValue({
+        results: [mockPost],
+      } as any)
+
+      vi.mocked(collectPaginatedAPI).mockRejectedValue(new Error('Failed to fetch blocks'))
+
+      const result = await getPost({
+        slug: 'test-post',
+        includeBlocks: true,
+        skipCache: true,
+      })
+
+      // Verify error propagated
+      expect(isErr(result)).toBe(true)
+      if (isErr(result)) {
+        expect(result.error.message).toContain('Failed to fetch blocks')
+      }
+    })
+  })
+
+  describe('Data transformation pipeline', () => {
+    it('transforms Notion pages → Posts → navigation structure', async () => {
+      const { collectPaginatedAPI } = await import('./client')
+
+      // Mock pages in descending order by date (as Notion API would return them)
+      const mockPages = [
+        {
+          id: 'post-2',
+          last_edited_time: '2024-01-15T00:00:00.000Z',
+          properties: {
+            Slug: { type: 'rich_text', rich_text: [{ plain_text: 'post-2' }] },
+            Title: { type: 'title', title: [{ plain_text: 'Post 2' }] },
+            Description: { type: 'rich_text', rich_text: [{ plain_text: 'Description 2' }] },
+            'First published': { type: 'date', date: { start: '2024-01-15' } },
+            'Featured image': { type: 'files', files: [] },
+          },
+        },
+        {
+          id: 'post-1',
+          last_edited_time: '2024-01-01T00:00:00.000Z',
+          properties: {
+            Slug: { type: 'rich_text', rich_text: [{ plain_text: 'post-1' }] },
+            Title: { type: 'title', title: [{ plain_text: 'Post 1' }] },
+            Description: { type: 'rich_text', rich_text: [{ plain_text: 'Description 1' }] },
+            'First published': { type: 'date', date: { start: '2024-01-01' } },
+            'Featured image': { type: 'files', files: [] },
+          },
+        },
+      ]
+
+      vi.mocked(collectPaginatedAPI).mockResolvedValueOnce(mockPages as any)
+
+      // Default sort is ascending, but mock data is in descending order (as returned by API)
+      const result = await getPosts({ sortDirection: 'descending', skipCache: true })
+
+      expect(isOk(result)).toBe(true)
+      if (!isOk(result)) return
+
+      const posts = result.value
+
+      // Verify transformation
+      expect(posts).toHaveLength(2)
+      expect(posts[0].slug).toBe('post-2') // Newer post first (descending order)
+      expect(posts[0].title).toBe('Post 2')
+      expect(posts[1].slug).toBe('post-1')
+      expect(posts[1].title).toBe('Post 1')
+
+      // Verify domain objects have flat structure (not nested Notion properties)
+      expect(posts[0]).toHaveProperty('slug')
+      expect(posts[0]).toHaveProperty('title')
+      expect(posts[0]).toHaveProperty('description')
+      expect(posts[0]).not.toHaveProperty('properties')
+    })
+
+    it('transforms Notion pages → MediaItems with category filter', async () => {
+      const { collectPaginatedAPI } = await import('./client')
+
+      const mockPages = [
+        {
+          id: 'book-1',
+          properties: {
+            Title: { type: 'title', title: [{ plain_text: 'Book Title' }] },
+            'Apple ID': { type: 'number', number: 123456 },
+            Date: { type: 'date', date: { start: '2024-01-15' } },
+          },
+        },
+      ]
+
+      vi.mocked(collectPaginatedAPI).mockResolvedValueOnce(mockPages as any)
+
+      const result = await getMediaItems({ category: 'books', skipCache: true })
+
+      expect(isOk(result)).toBe(true)
+      if (!isOk(result)) return
+
+      const items = result.value
+
+      // Verify transformation
+      expect(items).toHaveLength(1)
+      expect(items[0].name).toBe('Book Title')
+      expect(items[0].appleId).toBe(123456)
+      expect(items[0].date).toBe('2024-01-15')
+
+      // Verify flat structure
+      expect(items[0]).not.toHaveProperty('properties')
+    })
+  })
+
+  describe('Error handling at API boundaries', () => {
+    it('validates and rejects invalid Notion page data', async () => {
+      const notion = (await import('./client')).default
+      const { collectPaginatedAPI } = await import('./client')
+
+      // Missing required fields
+      const invalidPage = {
+        id: 'invalid-post',
+        last_edited_time: '2024-01-15T00:00:00.000Z',
+        properties: {
+          Slug: { type: 'rich_text', rich_text: [{ plain_text: null }] }, // Invalid: null slug
+          Title: { type: 'title', title: [{ plain_text: 'Valid Title' }] },
+          Description: { type: 'rich_text', rich_text: [] },
+          'First published': { type: 'date', date: { start: '2024-01-15' } },
+          'Featured image': { type: 'files', files: [] },
+        },
+      }
+
+      vi.mocked(collectPaginatedAPI).mockResolvedValueOnce([invalidPage] as any)
+
+      const result = await getPosts({ skipCache: true })
+
+      // Should return Err due to validation failure
+      expect(isErr(result)).toBe(true)
+      if (isErr(result)) {
+        expect(result.error.message).toContain('Invalid post')
+        expect(result.error.message).toContain('build aborted')
+      }
+    })
+
+    it('validates and rejects invalid block data', async () => {
+      const { collectPaginatedAPI } = await import('./client')
+
+      // Invalid block structure
+      const invalidBlocks = [
+        {
+          id: 'block-1',
+          type: 'unsupported_type', // Not in our schema
+          unsupported_type: {},
+        },
+      ]
+
+      vi.mocked(collectPaginatedAPI).mockResolvedValue(invalidBlocks as any)
+
+      const result = await getBlockChildren('test-block-id')
+
+      // Should return Err due to validation failure
+      expect(isErr(result)).toBe(true)
+      if (isErr(result)) {
+        expect(result.error.message).toContain('Invalid block data - build aborted')
+      }
+    })
+  })
+})

--- a/lib/tmdb/fetchTmdbList.test.ts
+++ b/lib/tmdb/fetchTmdbList.test.ts
@@ -1,0 +1,353 @@
+import fetchTmdbList from './fetchTmdbList'
+import { isOk, isErr } from '@/utils/result'
+
+// Mock dependencies
+vi.mock('@/lib/cloudinary/transformCloudinaryImage', () => ({
+  default: vi.fn((url: string) => url),
+}))
+
+vi.mock('@/utils/getImagePlaceholderForEnv', () => ({
+  default: vi.fn(async () => 'data:image/png;base64,placeholder'),
+}))
+
+vi.mock('@/lib/env', () => ({
+  env: {
+    TMDB_READ_ACCESS_TOKEN: 'mock-token',
+  },
+}))
+
+describe('fetchTmdbList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('success cases', () => {
+    it('returns Ok with valid TV shows from API', async () => {
+      const mockResponse = {
+        total_pages: 1,
+        results: [
+          {
+            id: 123,
+            name: 'Test TV Show',
+            first_air_date: '2024-01-15',
+            poster_path: '/poster.jpg',
+          },
+        ],
+      }
+
+      global.fetch = vi.fn(async () => ({
+        json: async () => mockResponse,
+      })) as any
+
+      const result = await fetchTmdbList('test-list-id', 'tv')
+
+      expect(isOk(result)).toBe(true)
+      if (isOk(result)) {
+        expect(result.value).toHaveLength(1)
+        expect(result.value[0]).toMatchObject({
+          id: '123',
+          title: 'Test TV Show',
+          date: '2024-01-15',
+          link: 'https://www.themoviedb.org/tv/123',
+        })
+      }
+    })
+
+    it('returns Ok with valid movies from API', async () => {
+      const mockResponse = {
+        total_pages: 1,
+        results: [
+          {
+            id: 456,
+            title: 'Test Movie',
+            release_date: '2024-03-20',
+            poster_path: '/movie-poster.jpg',
+          },
+        ],
+      }
+
+      global.fetch = vi.fn(async () => ({
+        json: async () => mockResponse,
+      })) as any
+
+      const result = await fetchTmdbList('test-list-id', 'movie')
+
+      expect(isOk(result)).toBe(true)
+      if (isOk(result)) {
+        expect(result.value).toHaveLength(1)
+        expect(result.value[0]).toMatchObject({
+          id: '456',
+          title: 'Test Movie',
+          date: '2024-03-20',
+          link: 'https://www.themoviedb.org/movie/456',
+        })
+      }
+    })
+
+    it('handles pagination correctly', async () => {
+      let callCount = 0
+      global.fetch = vi.fn(async () => {
+        callCount++
+        return {
+          json: async () => ({
+            total_pages: 2,
+            results: [
+              {
+                id: callCount,
+                title: `Movie ${callCount}`,
+                release_date: '2024-01-15',
+                poster_path: '/poster.jpg',
+              },
+            ],
+          }),
+        }
+      }) as any
+
+      const result = await fetchTmdbList('test-list-id', 'movie')
+
+      expect(global.fetch).toHaveBeenCalledTimes(2)
+      expect(isOk(result)).toBe(true)
+      if (isOk(result)) {
+        expect(result.value).toHaveLength(2)
+        expect(result.value[0].title).toBe('Movie 1')
+        expect(result.value[1].title).toBe('Movie 2')
+      }
+    })
+
+    it('filters out invalid items but returns Ok with valid ones', async () => {
+      const mockResponse = {
+        total_pages: 1,
+        results: [
+          {
+            id: 1,
+            title: 'Valid Movie',
+            release_date: '2024-01-15',
+            poster_path: '/poster1.jpg',
+          },
+          {
+            // Missing poster_path - should be filtered
+            id: 2,
+            title: 'Invalid Movie',
+            release_date: '2024-02-15',
+          },
+          {
+            id: 3,
+            title: 'Another Valid Movie',
+            release_date: '2024-03-15',
+            poster_path: '/poster3.jpg',
+          },
+        ],
+      }
+
+      global.fetch = vi.fn(async () => ({
+        json: async () => mockResponse,
+      })) as any
+
+      const result = await fetchTmdbList('test-list-id', 'movie')
+
+      expect(isOk(result)).toBe(true)
+      if (isOk(result)) {
+        expect(result.value).toHaveLength(2)
+        expect(result.value[0].id).toBe('1')
+        expect(result.value[1].id).toBe('3')
+      }
+    })
+
+    it('deduplicates items with same ID', async () => {
+      const mockResponse = {
+        total_pages: 1,
+        results: [
+          {
+            id: 1,
+            title: 'Movie 1',
+            release_date: '2024-01-15',
+            poster_path: '/poster.jpg',
+          },
+          {
+            id: 1, // Duplicate
+            title: 'Movie 1',
+            release_date: '2024-01-15',
+            poster_path: '/poster.jpg',
+          },
+        ],
+      }
+
+      global.fetch = vi.fn(async () => ({
+        json: async () => mockResponse,
+      })) as any
+
+      const result = await fetchTmdbList('test-list-id', 'movie')
+
+      expect(isOk(result)).toBe(true)
+      if (isOk(result)) {
+        expect(result.value).toHaveLength(1)
+      }
+    })
+
+    it('skips items with missing title/name', async () => {
+      const mockResponse = {
+        total_pages: 1,
+        results: [
+          {
+            id: 1,
+            title: 'Valid Movie',
+            release_date: '2024-01-15',
+            poster_path: '/poster.jpg',
+          },
+          {
+            id: 2,
+            // Missing title
+            release_date: '2024-02-15',
+            poster_path: '/poster.jpg',
+          },
+        ],
+      }
+
+      global.fetch = vi.fn(async () => ({
+        json: async () => mockResponse,
+      })) as any
+
+      const result = await fetchTmdbList('test-list-id', 'movie')
+
+      expect(isOk(result)).toBe(true)
+      if (isOk(result)) {
+        expect(result.value).toHaveLength(1)
+        expect(result.value[0].id).toBe('1')
+      }
+    })
+
+    it('skips items with missing date', async () => {
+      const mockResponse = {
+        total_pages: 1,
+        results: [
+          {
+            id: 1,
+            title: 'Valid Movie',
+            release_date: '2024-01-15',
+            poster_path: '/poster.jpg',
+          },
+          {
+            id: 2,
+            title: 'Movie Without Date',
+            // Missing release_date
+            poster_path: '/poster.jpg',
+          },
+        ],
+      }
+
+      global.fetch = vi.fn(async () => ({
+        json: async () => mockResponse,
+      })) as any
+
+      const result = await fetchTmdbList('test-list-id', 'movie')
+
+      expect(isOk(result)).toBe(true)
+      if (isOk(result)) {
+        expect(result.value).toHaveLength(1)
+        expect(result.value[0].id).toBe('1')
+      }
+    })
+
+    it('returns Ok with empty array when no valid items', async () => {
+      const mockResponse = {
+        total_pages: 1,
+        results: [],
+      }
+
+      global.fetch = vi.fn(async () => ({
+        json: async () => mockResponse,
+      })) as any
+
+      const result = await fetchTmdbList('test-list-id', 'movie')
+
+      expect(isOk(result)).toBe(true)
+      if (isOk(result)) {
+        expect(result.value).toEqual([])
+      }
+    })
+  })
+
+  describe('error cases', () => {
+    it('returns Err when listId is empty', async () => {
+      const result = await fetchTmdbList('', 'movie')
+
+      expect(isErr(result)).toBe(true)
+      if (isErr(result)) {
+        expect(result.error.message).toBe('fetchTmdbList: listId is required')
+      }
+    })
+
+    it('returns Err when fetch fails', async () => {
+      const networkError = new Error('Network error')
+      global.fetch = vi.fn(async () => {
+        throw networkError
+      }) as any
+
+      const result = await fetchTmdbList('test-list-id', 'movie')
+
+      expect(isErr(result)).toBe(true)
+      if (isErr(result)) {
+        expect(result.error).toBe(networkError)
+      }
+    })
+
+    it('returns Err when JSON parsing fails', async () => {
+      global.fetch = vi.fn(async () => ({
+        json: async () => {
+          throw new Error('Invalid JSON')
+        },
+      })) as any
+
+      const result = await fetchTmdbList('test-list-id', 'movie')
+
+      expect(isErr(result)).toBe(true)
+      if (isErr(result)) {
+        expect(result.error.message).toBe('Invalid JSON')
+      }
+    })
+
+    it('wraps non-Error exceptions as Error', async () => {
+      global.fetch = vi.fn(async () => {
+        throw 'string error'
+      }) as any
+
+      const result = await fetchTmdbList('test-list-id', 'movie')
+
+      expect(isErr(result)).toBe(true)
+      if (isErr(result)) {
+        expect(result.error).toBeInstanceOf(Error)
+        expect(result.error.message).toBe('string error')
+      }
+    })
+
+    it('returns Err on error during pagination', async () => {
+      let callCount = 0
+      global.fetch = vi.fn(async () => {
+        callCount++
+        if (callCount === 2) {
+          throw new Error('Pagination error')
+        }
+        return {
+          json: async () => ({
+            total_pages: 3,
+            results: [
+              {
+                id: callCount,
+                title: `Movie ${callCount}`,
+                release_date: '2024-01-15',
+                poster_path: '/poster.jpg',
+              },
+            ],
+          }),
+        }
+      }) as any
+
+      const result = await fetchTmdbList('test-list-id', 'movie')
+
+      expect(isErr(result)).toBe(true)
+      if (isErr(result)) {
+        expect(result.error.message).toBe('Pagination error')
+      }
+    })
+  })
+})

--- a/lib/tmdb/fetchTmdbList.ts
+++ b/lib/tmdb/fetchTmdbList.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 import transformCloudinaryImage from '@/lib/cloudinary/transformCloudinaryImage'
 import getImagePlaceholderForEnv from '@/utils/getImagePlaceholderForEnv'
 import { env } from '@/lib/env'
-import { type Result, Ok, Err } from '@/utils/result'
+import { type Result, Ok, Err, toErr } from '@/utils/result'
 
 // Schema for raw TMDB API response item
 const TmdbApiResultSchema = z.object({
@@ -114,8 +114,7 @@ export default async function fetchTmdbList(
         }
       }
     } catch (error) {
-      console.error('fetchTmdbList error:', error)
-      return Err(error instanceof Error ? error : new Error(String(error)))
+      return toErr(error, 'fetchTmdbList')
     }
 
     page++

--- a/lib/tmdb/fetchTmdbList.ts
+++ b/lib/tmdb/fetchTmdbList.ts
@@ -121,5 +121,5 @@ export default async function fetchTmdbList(
     page++
   } while (page <= totalPages)
 
-  return Ok(await Promise.all(items))
+  return Ok(items)
 }

--- a/lib/tmdb/fetchTmdbList.ts
+++ b/lib/tmdb/fetchTmdbList.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 import transformCloudinaryImage from '@/lib/cloudinary/transformCloudinaryImage'
 import getImagePlaceholderForEnv from '@/utils/getImagePlaceholderForEnv'
 import { env } from '@/lib/env'
+import { type Result, Ok, Err } from '@/utils/result'
 
 // Schema for raw TMDB API response item
 const TmdbApiResultSchema = z.object({
@@ -25,10 +26,14 @@ const TmdbItemSchema = z.object({
 
 export type TmdbItem = z.infer<typeof TmdbItemSchema>
 
-export default async function fetchTmdbList(listId: string, api: 'tv' | 'movie'): Promise<TmdbItem[]> {
+export default async function fetchTmdbList(
+  listId: string,
+  api: 'tv' | 'movie',
+): Promise<Result<TmdbItem[], Error>> {
   if (!listId) {
-    console.log('fetchTmdbList error: listId is undefined')
-    return []
+    const error = new Error('fetchTmdbList: listId is required')
+    console.error(error.message)
+    return Err(error)
   }
 
   const items = []
@@ -109,11 +114,12 @@ export default async function fetchTmdbList(listId: string, api: 'tv' | 'movie')
         }
       }
     } catch (error) {
-      console.log('fetchTmdbList error:', error)
+      console.error('fetchTmdbList error:', error)
+      return Err(error instanceof Error ? error : new Error(String(error)))
     }
 
     page++
   } while (page <= totalPages)
 
-  return await Promise.all(items)
+  return Ok(await Promise.all(items))
 }

--- a/ui/image.tsx
+++ b/ui/image.tsx
@@ -25,7 +25,7 @@ export default async function Image({ loading = 'eager', url, showCaption, image
     throw new Error(`🚨 Image URL is not a Cloudinary URL: "${url}"`)
   }
 
-  const { alt, caption, height, sizes, src, srcSet, width } = await fetchCloudinaryImageMetadata(url)
+  const { alt, caption, height, sizes, src, srcSet, width } = (await fetchCloudinaryImageMetadata(url)).unwrap()
 
   const imageClasses = imageStyles ? `${imageStylesDefault} ${imageStyles}` : imageStylesDefault
   const outerClasses = outerStyles ? `${outerStylesDefault} ${outerStyles}` : outerStylesDefault

--- a/utils/result.test.ts
+++ b/utils/result.test.ts
@@ -1,10 +1,10 @@
-import { Ok, Err, isOk, isErr, unwrap, unwrapOr, map, mapErr, flatMap } from './result'
+import { Ok, Err, isOk, isErr } from './result'
 
 describe('Result type', () => {
   describe('Ok', () => {
     it('creates a successful Result', () => {
       const result = Ok(42)
-      expect(result).toEqual({ ok: true, value: 42 })
+      expect(result).toMatchObject({ ok: true, value: 42 })
     })
 
     it('preserves type of value', () => {
@@ -17,7 +17,7 @@ describe('Result type', () => {
     it('creates a failed Result', () => {
       const error = new Error('Something went wrong')
       const result = Err(error)
-      expect(result).toEqual({ ok: false, error })
+      expect(result).toMatchObject({ ok: false, error })
     })
 
     it('can hold any error type', () => {
@@ -37,7 +37,7 @@ describe('Result type', () => {
       expect(isOk(result)).toBe(false)
     })
 
-    it('narrows type to Ok', () => {
+    it('narrows type to OkResult', () => {
       const result = Ok(42)
       if (isOk(result)) {
         // TypeScript should know result.value exists
@@ -57,7 +57,7 @@ describe('Result type', () => {
       expect(isErr(result)).toBe(false)
     })
 
-    it('narrows type to Err', () => {
+    it('narrows type to ErrResult', () => {
       const result = Err(new Error('fail'))
       if (isErr(result)) {
         // TypeScript should know result.error exists
@@ -66,107 +66,119 @@ describe('Result type', () => {
     })
   })
 
-  describe('unwrap', () => {
+  describe('unwrap method', () => {
     it('returns value from Ok result', () => {
       const result = Ok(42)
-      expect(unwrap(result)).toBe(42)
+      expect(result.unwrap()).toBe(42)
     })
 
     it('throws error from Err result', () => {
       const error = new Error('Something went wrong')
       const result = Err(error)
-      expect(() => unwrap(result)).toThrow(error)
+      expect(() => result.unwrap()).toThrow(error)
     })
 
     it('preserves error message when throwing', () => {
       const result = Err(new Error('Custom error'))
-      expect(() => unwrap(result)).toThrow('Custom error')
+      expect(() => result.unwrap()).toThrow('Custom error')
     })
   })
 
-  describe('unwrapOr', () => {
+  describe('unwrapOr method', () => {
     it('returns value from Ok result', () => {
       const result = Ok(42)
-      expect(unwrapOr(result, 0)).toBe(42)
+      expect(result.unwrapOr(0)).toBe(42)
     })
 
     it('returns default value from Err result', () => {
       const result = Err(new Error('fail'))
-      expect(unwrapOr(result, 0)).toBe(0)
+      expect(result.unwrapOr(0)).toBe(0)
     })
 
     it('works with complex default values', () => {
       const result = Err(new Error('fail'))
       const defaultValue = { items: [], count: 0 }
-      expect(unwrapOr(result, defaultValue)).toEqual({ items: [], count: 0 })
+      expect(result.unwrapOr(defaultValue)).toEqual({ items: [], count: 0 })
     })
   })
 
-  describe('map', () => {
+  describe('map method', () => {
     it('transforms Ok value', () => {
       const result = Ok(42)
-      const mapped = map(result, (n) => n * 2)
-      expect(mapped).toEqual(Ok(84))
+      const mapped = result.map((n) => n * 2)
+      expect(mapped).toMatchObject({ ok: true, value: 84 })
     })
 
     it('preserves Err without calling function', () => {
       const error = new Error('fail')
       const result = Err(error)
-      const mapped = map(result, (n: number) => n * 2)
-      expect(mapped).toEqual(Err(error))
+      const mapped = result.map((n: number) => n * 2)
+      expect(mapped).toMatchObject({ ok: false, error })
     })
 
     it('can change value type', () => {
       const result = Ok(42)
-      const mapped = map(result, (n) => String(n))
-      expect(mapped).toEqual(Ok('42'))
+      const mapped = result.map((n) => String(n))
+      expect(mapped).toMatchObject({ ok: true, value: '42' })
+    })
+
+    it('can chain map calls', () => {
+      const result = Ok(10)
+      const mapped = result.map((n) => n * 2).map((n) => n + 5)
+      expect(mapped).toMatchObject({ ok: true, value: 25 })
     })
   })
 
-  describe('mapErr', () => {
+  describe('mapErr method', () => {
     it('transforms Err error', () => {
       const result = Err(new Error('original'))
-      const mapped = mapErr(result, (e) => new Error(`Wrapped: ${e.message}`))
-      expect(mapped).toEqual(Err(new Error('Wrapped: original')))
+      const mapped = result.mapErr((e) => new Error(`Wrapped: ${e.message}`))
+      expect(isErr(mapped)).toBe(true)
+      if (isErr(mapped)) {
+        expect(mapped.error.message).toBe('Wrapped: original')
+      }
     })
 
     it('preserves Ok without calling function', () => {
       const result = Ok(42)
-      const mapped = mapErr(result, (e: Error) => new Error(`Wrapped: ${e.message}`))
-      expect(mapped).toEqual(Ok(42))
+      const mapped = result.mapErr((e: Error) => new Error(`Wrapped: ${e.message}`))
+      expect(mapped).toMatchObject({ ok: true, value: 42 })
     })
 
     it('can change error type', () => {
       const result = Err(new Error('fail'))
-      const mapped = mapErr(result, (e) => e.message)
-      expect(mapped).toEqual(Err('fail'))
+      const mapped = result.mapErr((e) => e.message)
+      expect(mapped).toMatchObject({ ok: false, error: 'fail' })
     })
   })
 
-  describe('flatMap', () => {
+  describe('flatMap method', () => {
     it('chains Ok results', () => {
       const result = Ok(42)
-      const chained = flatMap(result, (n) => Ok(n * 2))
-      expect(chained).toEqual(Ok(84))
+      const chained = result.flatMap((n) => Ok(n * 2))
+      expect(chained).toMatchObject({ ok: true, value: 84 })
     })
 
     it('chains and converts Ok to Err', () => {
       const result = Ok(42)
-      const chained = flatMap(result, (n) => (n > 50 ? Ok(n) : Err(new Error('too small'))))
-      expect(chained).toEqual(Err(new Error('too small')))
+      const chained = result.flatMap((n) => (n > 50 ? Ok(n) : Err(new Error('too small'))))
+      expect(isErr(chained)).toBe(true)
+      if (isErr(chained)) {
+        expect(chained.error.message).toBe('too small')
+      }
     })
 
     it('short-circuits on Err', () => {
       const error = new Error('original')
       const result = Err(error)
-      const chained = flatMap(result, (n: number) => Ok(n * 2))
-      expect(chained).toEqual(Err(error))
+      const chained = result.flatMap((n: number) => Ok(n * 2))
+      expect(chained).toMatchObject({ ok: false, error })
     })
 
     it('can change value type through chaining', () => {
       const result = Ok(42)
-      const chained = flatMap(result, (n) => Ok(String(n)))
-      expect(chained).toEqual(Ok('42'))
+      const chained = result.flatMap((n) => Ok(String(n)))
+      expect(chained).toMatchObject({ ok: true, value: '42' })
     })
   })
 
@@ -174,15 +186,15 @@ describe('Result type', () => {
     it('chains multiple operations', () => {
       const divide = (a: number, b: number) => (b === 0 ? Err(new Error('divide by zero')) : Ok(a / b))
 
-      const result = flatMap(divide(10, 2), (x) => flatMap(divide(x, 5), (y) => Ok(y * 3)))
+      const result = divide(10, 2).flatMap((x) => divide(x, 5).flatMap((y) => Ok(y * 3)))
 
-      expect(result).toEqual(Ok(3)) // (10 / 2) / 5 * 3 = 3
+      expect(result).toMatchObject({ ok: true, value: 3 }) // (10 / 2) / 5 * 3 = 3
     })
 
     it('handles error in chain', () => {
       const divide = (a: number, b: number) => (b === 0 ? Err(new Error('divide by zero')) : Ok(a / b))
 
-      const result = flatMap(divide(10, 0), (x) => flatMap(divide(x, 5), (y) => Ok(y * 3)))
+      const result = divide(10, 0).flatMap((x) => divide(x, 5).flatMap((y) => Ok(y * 3)))
 
       expect(isErr(result)).toBe(true)
       if (isErr(result)) {
@@ -194,8 +206,17 @@ describe('Result type', () => {
       const fetchUser = (id: number) =>
         id > 0 ? Ok({ id, name: 'Alice' }) : Err(new Error('Invalid ID'))
 
-      const user = unwrapOr(fetchUser(-1), { id: 0, name: 'Guest' })
+      const user = fetchUser(-1).unwrapOr({ id: 0, name: 'Guest' })
       expect(user).toEqual({ id: 0, name: 'Guest' })
+    })
+
+    it('fluent API with method chaining', () => {
+      const result = Ok([1, 2, 3, 4, 5])
+        .map((arr) => arr.filter((n) => n % 2 === 0))
+        .map((arr) => arr.map((n) => n * 2))
+        .unwrapOr([])
+
+      expect(result).toEqual([4, 8])
     })
   })
 })

--- a/utils/result.test.ts
+++ b/utils/result.test.ts
@@ -1,0 +1,201 @@
+import { Ok, Err, isOk, isErr, unwrap, unwrapOr, map, mapErr, flatMap } from './result'
+
+describe('Result type', () => {
+  describe('Ok', () => {
+    it('creates a successful Result', () => {
+      const result = Ok(42)
+      expect(result).toEqual({ ok: true, value: 42 })
+    })
+
+    it('preserves type of value', () => {
+      const result = Ok({ name: 'test', count: 10 })
+      expect(result.value).toEqual({ name: 'test', count: 10 })
+    })
+  })
+
+  describe('Err', () => {
+    it('creates a failed Result', () => {
+      const error = new Error('Something went wrong')
+      const result = Err(error)
+      expect(result).toEqual({ ok: false, error })
+    })
+
+    it('can hold any error type', () => {
+      const result = Err('string error')
+      expect(result.error).toBe('string error')
+    })
+  })
+
+  describe('isOk', () => {
+    it('returns true for Ok results', () => {
+      const result = Ok(42)
+      expect(isOk(result)).toBe(true)
+    })
+
+    it('returns false for Err results', () => {
+      const result = Err(new Error('fail'))
+      expect(isOk(result)).toBe(false)
+    })
+
+    it('narrows type to Ok', () => {
+      const result = Ok(42)
+      if (isOk(result)) {
+        // TypeScript should know result.value exists
+        expect(result.value).toBe(42)
+      }
+    })
+  })
+
+  describe('isErr', () => {
+    it('returns true for Err results', () => {
+      const result = Err(new Error('fail'))
+      expect(isErr(result)).toBe(true)
+    })
+
+    it('returns false for Ok results', () => {
+      const result = Ok(42)
+      expect(isErr(result)).toBe(false)
+    })
+
+    it('narrows type to Err', () => {
+      const result = Err(new Error('fail'))
+      if (isErr(result)) {
+        // TypeScript should know result.error exists
+        expect(result.error.message).toBe('fail')
+      }
+    })
+  })
+
+  describe('unwrap', () => {
+    it('returns value from Ok result', () => {
+      const result = Ok(42)
+      expect(unwrap(result)).toBe(42)
+    })
+
+    it('throws error from Err result', () => {
+      const error = new Error('Something went wrong')
+      const result = Err(error)
+      expect(() => unwrap(result)).toThrow(error)
+    })
+
+    it('preserves error message when throwing', () => {
+      const result = Err(new Error('Custom error'))
+      expect(() => unwrap(result)).toThrow('Custom error')
+    })
+  })
+
+  describe('unwrapOr', () => {
+    it('returns value from Ok result', () => {
+      const result = Ok(42)
+      expect(unwrapOr(result, 0)).toBe(42)
+    })
+
+    it('returns default value from Err result', () => {
+      const result = Err(new Error('fail'))
+      expect(unwrapOr(result, 0)).toBe(0)
+    })
+
+    it('works with complex default values', () => {
+      const result = Err(new Error('fail'))
+      const defaultValue = { items: [], count: 0 }
+      expect(unwrapOr(result, defaultValue)).toEqual({ items: [], count: 0 })
+    })
+  })
+
+  describe('map', () => {
+    it('transforms Ok value', () => {
+      const result = Ok(42)
+      const mapped = map(result, (n) => n * 2)
+      expect(mapped).toEqual(Ok(84))
+    })
+
+    it('preserves Err without calling function', () => {
+      const error = new Error('fail')
+      const result = Err(error)
+      const mapped = map(result, (n: number) => n * 2)
+      expect(mapped).toEqual(Err(error))
+    })
+
+    it('can change value type', () => {
+      const result = Ok(42)
+      const mapped = map(result, (n) => String(n))
+      expect(mapped).toEqual(Ok('42'))
+    })
+  })
+
+  describe('mapErr', () => {
+    it('transforms Err error', () => {
+      const result = Err(new Error('original'))
+      const mapped = mapErr(result, (e) => new Error(`Wrapped: ${e.message}`))
+      expect(mapped).toEqual(Err(new Error('Wrapped: original')))
+    })
+
+    it('preserves Ok without calling function', () => {
+      const result = Ok(42)
+      const mapped = mapErr(result, (e: Error) => new Error(`Wrapped: ${e.message}`))
+      expect(mapped).toEqual(Ok(42))
+    })
+
+    it('can change error type', () => {
+      const result = Err(new Error('fail'))
+      const mapped = mapErr(result, (e) => e.message)
+      expect(mapped).toEqual(Err('fail'))
+    })
+  })
+
+  describe('flatMap', () => {
+    it('chains Ok results', () => {
+      const result = Ok(42)
+      const chained = flatMap(result, (n) => Ok(n * 2))
+      expect(chained).toEqual(Ok(84))
+    })
+
+    it('chains and converts Ok to Err', () => {
+      const result = Ok(42)
+      const chained = flatMap(result, (n) => (n > 50 ? Ok(n) : Err(new Error('too small'))))
+      expect(chained).toEqual(Err(new Error('too small')))
+    })
+
+    it('short-circuits on Err', () => {
+      const error = new Error('original')
+      const result = Err(error)
+      const chained = flatMap(result, (n: number) => Ok(n * 2))
+      expect(chained).toEqual(Err(error))
+    })
+
+    it('can change value type through chaining', () => {
+      const result = Ok(42)
+      const chained = flatMap(result, (n) => Ok(String(n)))
+      expect(chained).toEqual(Ok('42'))
+    })
+  })
+
+  describe('real-world usage patterns', () => {
+    it('chains multiple operations', () => {
+      const divide = (a: number, b: number) => (b === 0 ? Err(new Error('divide by zero')) : Ok(a / b))
+
+      const result = flatMap(divide(10, 2), (x) => flatMap(divide(x, 5), (y) => Ok(y * 3)))
+
+      expect(result).toEqual(Ok(3)) // (10 / 2) / 5 * 3 = 3
+    })
+
+    it('handles error in chain', () => {
+      const divide = (a: number, b: number) => (b === 0 ? Err(new Error('divide by zero')) : Ok(a / b))
+
+      const result = flatMap(divide(10, 0), (x) => flatMap(divide(x, 5), (y) => Ok(y * 3)))
+
+      expect(isErr(result)).toBe(true)
+      if (isErr(result)) {
+        expect(result.error.message).toBe('divide by zero')
+      }
+    })
+
+    it('provides default value for error case', () => {
+      const fetchUser = (id: number) =>
+        id > 0 ? Ok({ id, name: 'Alice' }) : Err(new Error('Invalid ID'))
+
+      const user = unwrapOr(fetchUser(-1), { id: 0, name: 'Guest' })
+      expect(user).toEqual({ id: 0, name: 'Guest' })
+    })
+  })
+})

--- a/utils/result.ts
+++ b/utils/result.ts
@@ -136,3 +136,57 @@ export function isOk<T, E>(result: Result<T, E>): result is OkResult<T> {
 export function isErr<T, E>(result: Result<T, E>): result is ErrResult<E> {
   return result.ok === false
 }
+
+/**
+ * Normalizes any caught value to an Error instance.
+ *
+ * JavaScript allows throwing any value (not just Error objects).
+ * This helper ensures the value is always an Error instance with proper stack traces.
+ *
+ * @param error - The caught exception (can be Error, string, number, object, etc.)
+ * @returns Error instance
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   riskyOperation()
+ * } catch (error) {
+ *   const normalizedError = normalizeError(error)
+ *   logger.error(normalizedError.message, normalizedError.stack)
+ *   throw normalizedError
+ * }
+ * ```
+ */
+export function normalizeError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error))
+}
+
+/**
+ * Converts caught exceptions to ErrResult<Error>.
+ *
+ * Combines error normalization with Result wrapping and optional logging.
+ * This is the most common pattern for catch blocks in Result-returning functions.
+ *
+ * @param error - The caught exception (can be Error, string, number, object, etc.)
+ * @param context - Optional context string for logging (e.g., function name)
+ * @returns ErrResult containing an Error instance
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   const data = await externalAPI()
+ *   return Ok(data)
+ * } catch (error) {
+ *   return toErr(error, 'fetchData')
+ * }
+ * ```
+ */
+export function toErr(error: unknown, context?: string): ErrResult<Error> {
+  const normalizedError = normalizeError(error)
+
+  if (context) {
+    console.error(`${context} error:`, error)
+  }
+
+  return Err(normalizedError)
+}

--- a/utils/result.ts
+++ b/utils/result.ts
@@ -1,0 +1,87 @@
+/**
+ * Result type for operations that can fail.
+ * Represents either a successful value (Ok) or an error (Err).
+ *
+ * Inspired by Rust's Result type and functional error handling patterns.
+ */
+export type Result<T, E = Error> = Ok<T> | Err<E>
+
+export type Ok<T> = {
+  readonly ok: true
+  readonly value: T
+}
+
+export type Err<E> = {
+  readonly ok: false
+  readonly error: E
+}
+
+/**
+ * Create a successful Result
+ */
+export function Ok<T>(value: T): Ok<T> {
+  return { ok: true, value }
+}
+
+/**
+ * Create a failed Result
+ */
+export function Err<E>(error: E): Err<E> {
+  return { ok: false, error }
+}
+
+/**
+ * Check if a Result is Ok
+ */
+export function isOk<T, E>(result: Result<T, E>): result is Ok<T> {
+  return result.ok === true
+}
+
+/**
+ * Check if a Result is Err
+ */
+export function isErr<T, E>(result: Result<T, E>): result is Err<E> {
+  return result.ok === false
+}
+
+/**
+ * Extract value from Ok, or throw if Err
+ * Use with caution - only when you're sure the operation succeeded
+ */
+export function unwrap<T, E>(result: Result<T, E>): T {
+  if (result.ok) {
+    return result.value
+  }
+  throw result.error
+}
+
+/**
+ * Extract value from Ok, or return a default value if Err
+ */
+export function unwrapOr<T, E>(result: Result<T, E>, defaultValue: T): T {
+  return result.ok ? result.value : defaultValue
+}
+
+/**
+ * Map over the value in an Ok Result
+ */
+export function map<T, U, E>(result: Result<T, E>, fn: (value: T) => U): Result<U, E> {
+  return result.ok ? Ok(fn(result.value)) : result
+}
+
+/**
+ * Map over the error in an Err Result
+ */
+export function mapErr<T, E, F>(result: Result<T, E>, fn: (error: E) => F): Result<T, F> {
+  return result.ok ? result : Err(fn(result.error))
+}
+
+/**
+ * Chain multiple Result-returning operations
+ */
+export function flatMap<T, U, E>(
+  result: Result<T, E>,
+  fn: (value: T) => Result<U, E>
+): Result<U, E> {
+  return result.ok ? fn(result.value) : result
+}


### PR DESCRIPTION
## What

- Adds `Result<T, E>` type with method-based API (`unwrap()`, `unwrapOr()`, `map()`, `flatMap()`, `mapErr()`)
- Converts all external API functions to return `Result` instead of throwing:
  - iTunes API: `fetchItunesItems`
  - TMDB API: `fetchTmdbList`
  - Notion API: `getMediaItems`, `getPosts`, `getPost`, `getBlockChildren`
  - Cloudinary API: `fetchCloudinaryImageMetadata`
- Updates all call sites to use `.unwrap()` for build-time validation
- Adds comprehensive test coverage (1,900+ lines of new tests)

## Why

- **Build-time guarantees**: Using `unwrap()` ensures API failures prevent deployment rather than serving stale/partial data
- **Explicit error handling**: Functions that can fail now advertise it in their return type
- **Better testability**: Error cases are first-class values that can be tested without throw/catch
- **Type-safe error propagation**: `flatMap()` enables chaining fallible operations without nested try/catch

## How to validate

1. Run `npm test`
2. Expect all 153 tests to pass
3. Check any test file (e.g., `lib/notion/getPost.test.ts`) to see Result pattern in action
4. Run `npm run build`
5. Expect successful build (all API calls resolve at build time)

## Related

This is the first step in a larger refactoring to improve resilience and testability. Next steps:
- Add retry wrapper utility for transient failures
- Introduce simple DI pattern for easier testing