### PR TITLE
Add Zod validation to all external inputs

### DIFF
--- a/.claude/specs/input-validation-pattern.md
+++ b/.claude/specs/input-validation-pattern.md
@@ -16,6 +16,7 @@ This document describes the established pattern for validating external inputs u
 ### Schema Organization
 
 **Use inline schemas when:**
+
 - Schema is used in only one file
 - Type is not exported for use elsewhere
 - Simple, single-purpose validation
@@ -30,6 +31,7 @@ const TmdbApiResultSchema = z.object({
 ```
 
 **Use dedicated schema files when:**
+
 - Schema/type is shared across multiple files
 - Part of a domain with multiple related schemas
 - Types need to be exported for UI components
@@ -83,7 +85,7 @@ const item = ProcessedItemSchema.safeParse({
 const cached = await cache.get<Post>(
   'post-123',
   'notion',
-  PostSchema  // ← Schema ensures data integrity
+  PostSchema, // ← Schema ensures data integrity
 )
 
 // ⚠️ Avoid - no validation, unsafe
@@ -91,6 +93,7 @@ const cached = await cache.get<Post>('post-123', 'notion')
 ```
 
 **Benefits:**
+
 - Detects corrupted cache files → cache miss → re-fetch
 - Handles schema evolution gracefully
 - Prevents runtime errors from malformed data
@@ -104,10 +107,10 @@ const result = MySchema.safeParse(data)
 if (!result.success) {
   // Log helpful context
   console.warn(`Invalid data for ${key}:`, result.error.message)
-  return null  // or throw, depending on criticality
+  return null // or throw, depending on criticality
 }
 
-const validData = result.data  // TypeScript knows this is valid
+const validData = result.data // TypeScript knows this is valid
 ```
 
 ### 4. Optional vs Required Fields
@@ -116,10 +119,10 @@ Be explicit about optionality:
 
 ```typescript
 const Schema = z.object({
-  required: z.string(),           // Must exist
+  required: z.string(), // Must exist
   optional: z.string().optional(), // May be undefined
   nullable: z.string().nullable(), // May be null
-  nullish: z.string().nullish(),   // May be null or undefined
+  nullish: z.string().nullish(), // May be null or undefined
 })
 ```
 
@@ -134,7 +137,7 @@ const data = apiResponse as MyType
 // ✅ Good - runtime validation with safeParse
 const result = MySchema.safeParse(apiResponse)
 if (result.success) {
-  const data = result.data  // Validated
+  const data = result.data // Validated
 }
 ```
 

--- a/.claude/specs/input-validation-pattern.md
+++ b/.claude/specs/input-validation-pattern.md
@@ -1,0 +1,178 @@
+# Input Validation Pattern
+
+This document describes the established pattern for validating external inputs using Zod.
+
+## Principle: Validate at I/O Boundaries
+
+**All external data should be validated with Zod at the point it enters the system.**
+
+### What to Validate
+
+1. **Environment variables** - `lib/env.ts`
+2. **External API responses** - TMDB, iTunes, Notion, Cloudinary
+3. **Filesystem reads** - Cache files, config files
+4. **User inputs** - Query params, form data, route params (when needed)
+
+### Schema Organization
+
+**Use inline schemas when:**
+- Schema is used in only one file
+- Type is not exported for use elsewhere
+- Simple, single-purpose validation
+
+```typescript
+// ✅ Inline schema - used only here
+const TmdbApiResultSchema = z.object({
+  id: z.number(),
+  title: z.string(),
+  // ...
+})
+```
+
+**Use dedicated schema files when:**
+- Schema/type is shared across multiple files
+- Part of a domain with multiple related schemas
+- Types need to be exported for UI components
+
+```typescript
+// ✅ Dedicated file - lib/notion/schemas/post.ts
+export const PostListItemSchema = z.object({
+  id: z.string(),
+  slug: z.string(),
+  // ...
+})
+```
+
+## Patterns
+
+### 1. External API Validation
+
+**Dual-layer validation** - validate raw API response, then transform:
+
+```typescript
+// Define schemas
+const ApiResponseSchema = z.object({
+  raw_field: z.string(),
+  nested: z.object({ value: z.number() }),
+})
+
+const ProcessedItemSchema = z.object({
+  cleanField: z.string(),
+  value: z.number(),
+})
+
+// Validate raw response
+const apiResult = ApiResponseSchema.safeParse(rawResponse)
+if (!apiResult.success) {
+  throw new Error(`Invalid API response: ${apiResult.error.message}`)
+}
+
+// Transform and validate again
+const item = ProcessedItemSchema.safeParse({
+  cleanField: apiResult.data.raw_field,
+  value: apiResult.data.nested.value,
+})
+```
+
+### 2. Cache Validation
+
+**Always provide schema when reading from cache:**
+
+```typescript
+// ✅ Good - validates cached data
+const cached = await cache.get<Post>(
+  'post-123',
+  'notion',
+  PostSchema  // ← Schema ensures data integrity
+)
+
+// ⚠️ Avoid - no validation, unsafe
+const cached = await cache.get<Post>('post-123', 'notion')
+```
+
+**Benefits:**
+- Detects corrupted cache files → cache miss → re-fetch
+- Handles schema evolution gracefully
+- Prevents runtime errors from malformed data
+
+### 3. Error Handling
+
+Use `safeParse()` for graceful error handling:
+
+```typescript
+const result = MySchema.safeParse(data)
+if (!result.success) {
+  // Log helpful context
+  console.warn(`Invalid data for ${key}:`, result.error.message)
+  return null  // or throw, depending on criticality
+}
+
+const validData = result.data  // TypeScript knows this is valid
+```
+
+### 4. Optional vs Required Fields
+
+Be explicit about optionality:
+
+```typescript
+const Schema = z.object({
+  required: z.string(),           // Must exist
+  optional: z.string().optional(), // May be undefined
+  nullable: z.string().nullable(), // May be null
+  nullish: z.string().nullish(),   // May be null or undefined
+})
+```
+
+## Type Safety
+
+**Never use type assertions for external data:**
+
+```typescript
+// ❌ Bad - no runtime validation
+const data = apiResponse as MyType
+
+// ✅ Good - runtime validation with safeParse
+const result = MySchema.safeParse(apiResponse)
+if (result.success) {
+  const data = result.data  // Validated
+}
+```
+
+**Exception:** Type assertions are OK in tests and for backward compatibility (cache without schema).
+
+## Examples in Codebase
+
+- **Environment**: `lib/env.ts` - Validates all env vars at startup
+- **APIs**: `lib/cloudinary/fetchCloudinaryImageMetadata.ts` - Dual-layer validation
+- **Cache**: `lib/notion/getPosts.ts` - Cache with schema validation
+- **Blocks**: `lib/notion/schemas/block.ts` - Complex recursive validation
+
+## Adding New External Inputs
+
+When adding a new external data source:
+
+1. **Define schema** (inline or dedicated file based on usage)
+2. **Validate at boundary** using `safeParse()`
+3. **Handle errors** gracefully with context
+4. **Add schema to cache reads** if applicable
+5. **Write tests** for validation edge cases
+
+## Testing
+
+Test both success and failure cases:
+
+```typescript
+describe('validation', () => {
+  it('accepts valid data', () => {
+    const result = MySchema.safeParse(validData)
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects invalid data', () => {
+    const result = MySchema.safeParse(invalidData)
+    expect(result.success).toBe(false)
+  })
+})
+```
+
+See `lib/cache/filesystem.test.ts` for comprehensive validation testing examples.

--- a/.claude/specs/input-validation-pattern.md
+++ b/.claude/specs/input-validation-pattern.md
@@ -66,7 +66,7 @@ const ProcessedItemSchema = z.object({
 // Validate raw response
 const apiResult = ApiResponseSchema.safeParse(rawResponse)
 if (!apiResult.success) {
-  throw new Error(`Invalid API response: ${apiResult.error.message}`)
+  throw new Error(`Invalid API response: ${formatValidationError(apiResult.error)}`)
 }
 
 // Transform and validate again
@@ -111,6 +111,28 @@ if (!result.success) {
 }
 
 const validData = result.data // TypeScript knows this is valid
+```
+
+**Validation Error Helpers (`utils/zod.ts`):**
+
+Use these helpers for cleaner, more consistent error messages:
+
+```typescript
+import { formatValidationError, logValidationError } from '@/utils/zod'
+
+// For throwing errors - extracts field names and messages
+const result = MySchema.safeParse(data)
+if (!result.success) {
+  throw new Error(`Invalid data: ${formatValidationError(result.error)}`)
+  // Output: "Invalid data: title: Required, date: Invalid format"
+}
+
+// For logging warnings - includes context
+const result = MySchema.safeParse(data)
+if (!result.success) {
+  logValidationError(result.error, 'post metadata')
+  // Output: "Skipping invalid post metadata (title: Required, date: Invalid format)"
+}
 ```
 
 ### 4. Optional vs Required Fields

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Validate
 
 on:
   push:
@@ -8,7 +8,7 @@ on:
 
 jobs:
   format:
-    name: Check formatting
+    name: Formatting
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -20,7 +20,7 @@ jobs:
       - run: npx prettier --check .
 
   lint:
-    name: Lint
+    name: Linting
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -32,7 +32,7 @@ jobs:
       - run: npm run lint
 
   typecheck:
-    name: Type check
+    name: Types
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -44,7 +44,7 @@ jobs:
       - run: npm run typecheck
 
   test:
-    name: Run tests
+    name: Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,30 +7,50 @@ on:
     branches: [main]
 
 jobs:
-  test:
+  format:
+    name: Check formatting
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
+      - run: npm ci
+      - run: npx prettier --check .
 
-      - name: Install dependencies
-        run: npm ci
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run lint
 
-      - name: Check formatting
-        run: npx prettier --check .
+  typecheck:
+    name: Type check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run typecheck
 
-      - name: Lint
-        run: npm run lint
-
-      - name: Type check
-        run: npm run typecheck
-
-      - name: Run tests
-        run: npm run test:ci
+  test:
+    name: Run tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run test:ci

--- a/lib/cache/adapter.ts
+++ b/lib/cache/adapter.ts
@@ -5,19 +5,50 @@ import { getCached, setCached } from './filesystem'
  * Cache adapter interface for dependency injection.
  * Allows swapping cache implementations (filesystem, Redis, memory, etc.)
  * and easier testing without module mocking.
+ *
+ * ## Validation Pattern
+ * Always provide a Zod schema when reading from cache to ensure data integrity:
+ *
+ * @example
+ * ```typescript
+ * // ✅ Good - validates cached data
+ * const cached = await cache.get<PostListItem[]>(
+ *   'posts-list',
+ *   'notion',
+ *   z.array(PostListItemSchema)
+ * )
+ *
+ * // ⚠️ Avoid - no validation, unsafe
+ * const cached = await cache.get<PostListItem[]>('posts-list', 'notion')
+ * ```
+ *
+ * Benefits of validation:
+ * - Detects corrupted cache files
+ * - Handles schema evolution gracefully (cache miss on invalid data)
+ * - Prevents runtime errors from malformed data
  */
 export interface CacheAdapter {
   /**
    * Get a value from the cache.
+   *
    * @param key - The cache key
    * @param namespace - Optional namespace/directory for the cache
-   * @param schema - Optional Zod schema to validate cached data
+   * @param schema - Zod schema to validate cached data (strongly recommended)
    * @returns The cached value or null if not found/expired/invalid
+   *
+   * @example
+   * ```typescript
+   * const post = await cache.get('post-123', 'notion', PostSchema)
+   * ```
    */
   get<T>(key: string, namespace?: string, schema?: z.ZodSchema<T>): Promise<T | null>
 
   /**
    * Set a value in the cache.
+   *
+   * @param key - The cache key
+   * @param value - The value to cache (must be JSON-serializable)
+   * @param namespace - Optional namespace/directory for the cache
    */
   set<T>(key: string, value: T, namespace?: string): Promise<void>
 }

--- a/lib/cache/adapter.ts
+++ b/lib/cache/adapter.ts
@@ -1,3 +1,4 @@
+import { type z } from 'zod'
 import { getCached, setCached } from './filesystem'
 
 /**
@@ -8,9 +9,12 @@ import { getCached, setCached } from './filesystem'
 export interface CacheAdapter {
   /**
    * Get a value from the cache.
-   * @returns The cached value or null if not found/expired
+   * @param key - The cache key
+   * @param namespace - Optional namespace/directory for the cache
+   * @param schema - Optional Zod schema to validate cached data
+   * @returns The cached value or null if not found/expired/invalid
    */
-  get<T>(key: string, namespace?: string): Promise<T | null>
+  get<T>(key: string, namespace?: string, schema?: z.ZodSchema<T>): Promise<T | null>
 
   /**
    * Set a value in the cache.

--- a/lib/cache/filesystem.test.ts
+++ b/lib/cache/filesystem.test.ts
@@ -121,10 +121,7 @@ describe('filesystem cache', () => {
 
       await getCached('test/key:with*special?chars', 'namespace')
 
-      expect(readFile).toHaveBeenCalledWith(
-        expect.stringContaining('test-key-with-special-chars.json'),
-        'utf-8',
-      )
+      expect(readFile).toHaveBeenCalledWith(expect.stringContaining('test-key-with-special-chars.json'), 'utf-8')
     })
   })
 

--- a/lib/cache/filesystem.test.ts
+++ b/lib/cache/filesystem.test.ts
@@ -1,0 +1,181 @@
+import { getCached, setCached } from './filesystem'
+import { readFile, writeFile, mkdir } from 'fs/promises'
+import { z } from 'zod'
+
+vi.mock('fs/promises', () => ({
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+  mkdir: vi.fn(),
+}))
+
+describe('filesystem cache', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.unstubAllEnvs()
+  })
+
+  describe('getCached', () => {
+    const TestSchema = z.object({
+      name: z.string(),
+      count: z.number(),
+    })
+
+    it('returns null in production mode', async () => {
+      vi.stubEnv('NODE_ENV', 'production')
+
+      const result = await getCached('test-key')
+
+      expect(result).toBeNull()
+      expect(readFile).not.toHaveBeenCalled()
+    })
+
+    it('returns null when cache file does not exist', async () => {
+      vi.stubEnv('NODE_ENV', 'development')
+
+      vi.mocked(readFile).mockRejectedValue(new Error('ENOENT: no such file'))
+
+      const result = await getCached('test-key')
+
+      expect(result).toBeNull()
+    })
+
+    it('returns cached data when file exists and no schema provided', async () => {
+      vi.stubEnv('NODE_ENV', 'development')
+
+      const cachedData = {
+        cachedAt: '2024-01-01T00:00:00.000Z',
+        data: { name: 'test', count: 42 },
+      }
+
+      vi.mocked(readFile).mockResolvedValue(JSON.stringify(cachedData))
+
+      const result = await getCached('test-key')
+
+      expect(result).toEqual({ name: 'test', count: 42 })
+    })
+
+    it('validates cached data with schema when provided', async () => {
+      vi.stubEnv('NODE_ENV', 'development')
+
+      const cachedData = {
+        cachedAt: '2024-01-01T00:00:00.000Z',
+        data: { name: 'test', count: 42 },
+      }
+
+      vi.mocked(readFile).mockResolvedValue(JSON.stringify(cachedData))
+
+      const result = await getCached('test-key', 'default', TestSchema)
+
+      expect(result).toEqual({ name: 'test', count: 42 })
+    })
+
+    it('returns null when cached data fails schema validation', async () => {
+      vi.stubEnv('NODE_ENV', 'development')
+
+      const cachedData = {
+        cachedAt: '2024-01-01T00:00:00.000Z',
+        data: { name: 'test', count: 'invalid' }, // Should be number
+      }
+
+      vi.mocked(readFile).mockResolvedValue(JSON.stringify(cachedData))
+
+      const result = await getCached('test-key', 'default', TestSchema)
+
+      expect(result).toBeNull()
+    })
+
+    it('returns null when cache file has invalid structure', async () => {
+      vi.stubEnv('NODE_ENV', 'development')
+
+      const invalidCachedData = {
+        // Missing 'data' field
+        cachedAt: '2024-01-01T00:00:00.000Z',
+      }
+
+      vi.mocked(readFile).mockResolvedValue(JSON.stringify(invalidCachedData))
+
+      const result = await getCached('test-key', 'default', TestSchema)
+
+      expect(result).toBeNull()
+    })
+
+    it('returns null when cache file contains malformed JSON', async () => {
+      vi.stubEnv('NODE_ENV', 'development')
+
+      vi.mocked(readFile).mockResolvedValue('{ invalid json')
+
+      const result = await getCached('test-key')
+
+      expect(result).toBeNull()
+    })
+
+    it('sanitizes cache key for filesystem safety', async () => {
+      vi.stubEnv('NODE_ENV', 'development')
+
+      const cachedData = {
+        cachedAt: '2024-01-01T00:00:00.000Z',
+        data: { name: 'test', count: 42 },
+      }
+
+      vi.mocked(readFile).mockResolvedValue(JSON.stringify(cachedData))
+
+      await getCached('test/key:with*special?chars', 'namespace')
+
+      expect(readFile).toHaveBeenCalledWith(
+        expect.stringContaining('test-key-with-special-chars.json'),
+        'utf-8',
+      )
+    })
+  })
+
+  describe('setCached', () => {
+    it('does nothing in production mode', async () => {
+      vi.stubEnv('NODE_ENV', 'production')
+
+      await setCached('test-key', { name: 'test', count: 42 })
+
+      expect(writeFile).not.toHaveBeenCalled()
+    })
+
+    it('writes cache file in development mode', async () => {
+      vi.stubEnv('NODE_ENV', 'development')
+
+      vi.mocked(mkdir).mockResolvedValue(undefined)
+      vi.mocked(writeFile).mockResolvedValue()
+
+      await setCached('test-key', { name: 'test', count: 42 })
+
+      expect(mkdir).toHaveBeenCalled()
+
+      const writeCall = vi.mocked(writeFile).mock.calls[0]
+      expect(writeCall[0]).toContain('test-key.json')
+      expect(writeCall[1]).toContain('"name"')
+      expect(writeCall[1]).toContain('"test"')
+      expect(writeCall[2]).toBe('utf-8')
+    })
+
+    it('includes timestamp in cached data', async () => {
+      vi.stubEnv('NODE_ENV', 'development')
+
+      vi.mocked(mkdir).mockResolvedValue(undefined)
+      vi.mocked(writeFile).mockResolvedValue()
+
+      await setCached('test-key', { name: 'test', count: 42 })
+
+      const writeCall = vi.mocked(writeFile).mock.calls[0]
+      const writtenData = JSON.parse(writeCall[1] as string)
+
+      expect(writtenData).toHaveProperty('cachedAt')
+      expect(writtenData).toHaveProperty('data')
+      expect(writtenData.data).toEqual({ name: 'test', count: 42 })
+    })
+
+    it('does not throw on write failure', async () => {
+      vi.stubEnv('NODE_ENV', 'development')
+
+      vi.mocked(mkdir).mockRejectedValue(new Error('Permission denied'))
+
+      await expect(setCached('test-key', { name: 'test', count: 42 })).resolves.not.toThrow()
+    })
+  })
+})

--- a/lib/cache/filesystem.ts
+++ b/lib/cache/filesystem.ts
@@ -62,6 +62,7 @@ export async function getCached<T>(key: string, dir: string = 'default', schema?
     }
 
     console.log(`💾 Cache hit: ${key}`)
+    // Safe: cache file structure validated above, caller responsible for type safety without schema
     return data as T
   } catch {
     // Cache miss or read error - not a problem, just return null

--- a/lib/cache/filesystem.ts
+++ b/lib/cache/filesystem.ts
@@ -27,11 +27,7 @@ const CacheFileSchema = z.object({
  * @param schema - Optional Zod schema to validate the cached data
  * @returns The cached data if found and valid, null otherwise
  */
-export async function getCached<T>(
-  key: string,
-  dir: string = 'default',
-  schema?: z.ZodSchema<T>,
-): Promise<T | null> {
+export async function getCached<T>(key: string, dir: string = 'default', schema?: z.ZodSchema<T>): Promise<T | null> {
   // Only cache in development mode
   if (process.env.NODE_ENV !== 'development') {
     return null

--- a/lib/cache/filesystem.ts
+++ b/lib/cache/filesystem.ts
@@ -65,8 +65,12 @@ export async function getCached<T>(key: string, dir: string = 'default', schema?
     console.log(`💾 Cache hit: ${key}`)
     // Safe: cache file structure validated above, caller responsible for type safety without schema
     return data as T
-  } catch {
-    // Cache miss or read error - not a problem, just return null
+  } catch (error) {
+    // Expected: ENOENT (cache miss) - stay quiet
+    // Unexpected: permission errors, disk issues - log for debugging
+    if (error && typeof error === 'object' && 'code' in error && error.code !== 'ENOENT') {
+      console.warn(`⚠️  Cache read error for ${key}:`, error)
+    }
     return null
   }
 }

--- a/lib/cache/filesystem.ts
+++ b/lib/cache/filesystem.ts
@@ -1,6 +1,7 @@
 import { mkdir, readFile, writeFile } from 'fs/promises'
 import { join } from 'path'
 import { z } from 'zod'
+import { formatValidationError } from '@/utils/zod'
 
 /**
  * Sanitizes a cache key to be safe for use as a filename.
@@ -44,7 +45,7 @@ export async function getCached<T>(key: string, dir: string = 'default', schema?
     // Validate cache file structure
     const cacheFileResult = CacheFileSchema.safeParse(parsed)
     if (!cacheFileResult.success) {
-      console.warn(`⚠️  Invalid cache file structure for ${key}, ignoring cache`)
+      console.warn(`⚠️  Invalid cache file structure for ${key}: ${formatValidationError(cacheFileResult.error)}`)
       return null
     }
 
@@ -54,7 +55,7 @@ export async function getCached<T>(key: string, dir: string = 'default', schema?
     if (schema) {
       const dataResult = schema.safeParse(data)
       if (!dataResult.success) {
-        console.warn(`⚠️  Invalid cached data for ${key}, ignoring cache`)
+        console.warn(`⚠️  Invalid cached data for ${key}: ${formatValidationError(dataResult.error)}`)
         return null
       }
       console.log(`💾 Cache hit: ${key}`)

--- a/lib/cache/filesystem.ts
+++ b/lib/cache/filesystem.ts
@@ -1,5 +1,6 @@
 import { mkdir, readFile, writeFile } from 'fs/promises'
 import { join } from 'path'
+import { z } from 'zod'
 
 /**
  * Sanitizes a cache key to be safe for use as a filename.
@@ -10,14 +11,27 @@ function sanitizeCacheKey(key: string): string {
 }
 
 /**
+ * Schema for the cache file structure
+ */
+const CacheFileSchema = z.object({
+  cachedAt: z.string(),
+  data: z.unknown(), // Will be validated by the provided schema
+})
+
+/**
  * Gets cached data from the filesystem.
  * Only operates in development mode.
  *
  * @param key - The cache key (will be sanitized for filesystem use)
  * @param dir - Optional subdirectory within .local-cache (default: 'default')
- * @returns The cached data if found, null otherwise
+ * @param schema - Optional Zod schema to validate the cached data
+ * @returns The cached data if found and valid, null otherwise
  */
-export async function getCached<T>(key: string, dir: string = 'default'): Promise<T | null> {
+export async function getCached<T>(
+  key: string,
+  dir: string = 'default',
+  schema?: z.ZodSchema<T>,
+): Promise<T | null> {
   // Only cache in development mode
   if (process.env.NODE_ENV !== 'development') {
     return null
@@ -31,8 +45,28 @@ export async function getCached<T>(key: string, dir: string = 'default'): Promis
     const fileContents = await readFile(filePath, 'utf-8')
     const parsed = JSON.parse(fileContents)
 
+    // Validate cache file structure
+    const cacheFileResult = CacheFileSchema.safeParse(parsed)
+    if (!cacheFileResult.success) {
+      console.warn(`⚠️  Invalid cache file structure for ${key}, ignoring cache`)
+      return null
+    }
+
+    const { data } = cacheFileResult.data
+
+    // Validate cached data if schema provided
+    if (schema) {
+      const dataResult = schema.safeParse(data)
+      if (!dataResult.success) {
+        console.warn(`⚠️  Invalid cached data for ${key}, ignoring cache`)
+        return null
+      }
+      console.log(`💾 Cache hit: ${key}`)
+      return dataResult.data
+    }
+
     console.log(`💾 Cache hit: ${key}`)
-    return parsed.data as T
+    return data as T
   } catch {
     // Cache miss or read error - not a problem, just return null
     return null

--- a/lib/cloudinary/fetchCloudinaryImageMetadata.ts
+++ b/lib/cloudinary/fetchCloudinaryImageMetadata.ts
@@ -1,6 +1,7 @@
 import { filesystemCache, type CacheAdapter } from '@/lib/cache/adapter'
 import cloudinary, { type CloudinaryClient } from '@/lib/cloudinary/client'
 import { getErrorDetails } from '@/utils/logging'
+import { formatValidationError } from '@/utils/zod'
 import parsePublicIdFromCloudinaryUrl from './parsePublicIdFromCloudinaryUrl'
 import { Ok, toErr, type Result } from '@/utils/result'
 import { z } from 'zod'
@@ -131,7 +132,8 @@ export default async function fetchCloudinaryImageMetadata({
     // Validate response with Zod
     const parseResult = CloudinaryResourceSchema.safeParse(cloudinaryResponse)
     if (!parseResult.success) {
-      throw new Error(`🚨 Invalid Cloudinary API response for "${publicId}":\n${parseResult.error.message}`)
+      const errors = formatValidationError(parseResult.error)
+      throw new Error(`🚨 Invalid Cloudinary API response for "${publicId}": ${errors}`)
     }
 
     const { public_id, width, height, context } = parseResult.data

--- a/lib/cloudinary/fetchCloudinaryImageMetadata.ts
+++ b/lib/cloudinary/fetchCloudinaryImageMetadata.ts
@@ -113,11 +113,7 @@ export default async function fetchCloudinaryImageMetadata({
     }
 
     // Check cache first (dev mode only)
-    const cached = await cache.get<CloudinaryImageMetadata>(
-      publicId,
-      'cloudinary',
-      CloudinaryImageMetadataSchema,
-    )
+    const cached = await cache.get<CloudinaryImageMetadata>(publicId, 'cloudinary', CloudinaryImageMetadataSchema)
     if (cached) return Ok(cached)
 
     console.log(`📥 Fetching Cloudinary image metadata from API for "${publicId}"`)
@@ -135,9 +131,7 @@ export default async function fetchCloudinaryImageMetadata({
     // Validate response with Zod
     const parseResult = CloudinaryResourceSchema.safeParse(cloudinaryResponse)
     if (!parseResult.success) {
-      throw new Error(
-        `🚨 Invalid Cloudinary API response for "${publicId}":\n${parseResult.error.message}`,
-      )
+      throw new Error(`🚨 Invalid Cloudinary API response for "${publicId}":\n${parseResult.error.message}`)
     }
 
     const { public_id, width, height, context } = parseResult.data

--- a/lib/itunes/fetchItunesItems.ts
+++ b/lib/itunes/fetchItunesItems.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 import transformCloudinaryImage from '@/lib/cloudinary/transformCloudinaryImage'
 import getImagePlaceholderForEnv from '@/utils/getImagePlaceholderForEnv'
+import { formatValidationError } from '@/utils/zod'
 import { type Result, Ok, toErr } from '@/utils/result'
 
 interface iTunesListItem {
@@ -68,7 +69,7 @@ export default async function fetchItunesItems(
         // Validate raw iTunes API data at boundary
         const parsedResult = iTunesApiResultSchema.safeParse(result)
         if (!parsedResult.success) {
-          console.log('Skipping invalid iTunes result:', parsedResult.error.format())
+          console.log('Skipping invalid iTunes result:', formatValidationError(parsedResult.error))
           return null
         }
 

--- a/lib/notion/getMediaItems.ts
+++ b/lib/notion/getMediaItems.ts
@@ -117,7 +117,7 @@ export default async function getMediaItems(options: Options): Promise<Result<No
     // Check cache first (cache utility handles dev mode check)
     const cacheKey = `media-${category}`
     if (!skipCache) {
-      const cached = await cache.get<NotionMediaItem[]>(cacheKey, 'notion')
+      const cached = await cache.get<NotionMediaItem[]>(cacheKey, 'notion', z.array(NotionMediaItemSchema))
       if (cached) {
         return Ok(cached)
       }

--- a/lib/notion/getPost.test.ts
+++ b/lib/notion/getPost.test.ts
@@ -442,13 +442,13 @@ describe('getPost', () => {
       const mockClient = createMockNotionClient()
 
       await getPost({ slug: 'test', cache: mockCache, notionClient: mockClient })
-      expect(mockCache.get).toHaveBeenCalledWith('post-test-blocks-false-nav-false', 'notion')
+      expect(mockCache.get).toHaveBeenCalledWith('post-test-blocks-false-nav-false', 'notion', expect.any(Object))
 
       await getPost({ slug: 'test', includeBlocks: true, cache: mockCache, notionClient: mockClient })
-      expect(mockCache.get).toHaveBeenCalledWith('post-test-blocks-true-nav-false', 'notion')
+      expect(mockCache.get).toHaveBeenCalledWith('post-test-blocks-true-nav-false', 'notion', expect.any(Object))
 
       await getPost({ slug: 'test', includePrevAndNext: true, cache: mockCache, notionClient: mockClient })
-      expect(mockCache.get).toHaveBeenCalledWith('post-test-blocks-false-nav-true', 'notion')
+      expect(mockCache.get).toHaveBeenCalledWith('post-test-blocks-false-nav-true', 'notion', expect.any(Object))
     })
   })
 

--- a/lib/notion/getPost.ts
+++ b/lib/notion/getPost.ts
@@ -2,7 +2,7 @@ import { filesystemCache, type CacheAdapter } from '@/lib/cache/adapter'
 import notion, { type Client } from './client'
 import getBlockChildren from '@/lib/notion/getBlockChildren'
 import getPosts from '@/lib/notion/getPosts'
-import { PostListItemSchema, PostPropertiesSchema, type Post } from './schemas/post'
+import { PostListItemSchema, PostPropertiesSchema, PostSchema, type Post } from './schemas/post'
 import { PageMetadataSchema } from './schemas/page'
 import { logValidationError } from '@/utils/zod'
 import { env } from '@/lib/env'
@@ -97,7 +97,7 @@ export default async function getPost({
     // Check cache first (cache utility handles dev mode check)
     const cacheKey = `post-${slug}-blocks-${includeBlocks}-nav-${includePrevAndNext}`
     if (!skipCache) {
-      const cached = await cache.get<Post>(cacheKey, 'notion')
+      const cached = await cache.get<Post>(cacheKey, 'notion', PostSchema)
       if (cached) {
         return Ok(cached)
       }

--- a/lib/notion/getPosts.test.ts
+++ b/lib/notion/getPosts.test.ts
@@ -362,7 +362,7 @@ describe('getPosts', () => {
 
       await getPosts({ sortDirection: 'descending', cache: mockCache, notionClient: mockClient })
 
-      expect(mockCache.get).toHaveBeenCalledWith('posts-list-descending', 'notion')
+      expect(mockCache.get).toHaveBeenCalledWith('posts-list-descending', 'notion', expect.any(Object))
       expect(mockCache.set).toHaveBeenCalledWith('posts-list-descending', expect.any(Array), 'notion')
     })
 

--- a/lib/notion/getPosts.ts
+++ b/lib/notion/getPosts.ts
@@ -5,6 +5,7 @@ import { PageMetadataSchema } from './schemas/page'
 import { logValidationError } from '@/utils/zod'
 import { env } from '@/lib/env'
 import { type Result, Ok, toErr } from '@/utils/result'
+import { z } from 'zod'
 
 type Options = {
   sortDirection?: 'ascending' | 'descending'
@@ -74,7 +75,7 @@ export default async function getPosts(options: Options = {}): Promise<Result<Po
     // Check cache first (cache utility handles dev mode check)
     const cacheKey = `posts-list-${sortDirection}`
     if (!skipCache) {
-      const cached = await cache.get<PostListItem[]>(cacheKey, 'notion')
+      const cached = await cache.get<PostListItem[]>(cacheKey, 'notion', z.array(PostListItemSchema))
       if (cached) {
         return Ok(cached)
       }

--- a/lib/notion/schemas/post.ts
+++ b/lib/notion/schemas/post.ts
@@ -34,6 +34,16 @@ export const PostListItemSchema = z.object({
 // Infer TypeScript type from Zod schema (single source of truth)
 export type PostListItem = z.infer<typeof PostListItemSchema>
 
+// Schema for full post (includes blocks and all metadata)
+// Used for validating cached post data
+// Note: blocks are typed as unknown for cache validation since they're validated separately
+export const PostSchema = PostListItemSchema.extend({
+  blocks: z.array(z.unknown()), // Validated separately in getBlockChildren
+  lastEditedTime: z.string(),
+  prevPost: PostListItemSchema.nullable(),
+  nextPost: PostListItemSchema.nullable(),
+})
+
 // Full post (includes blocks and all metadata)
 // Note: blocks are validated in getBlockChildren, not here
 export type Post = PostListItem & {

--- a/lib/notion/schemas/post.ts
+++ b/lib/notion/schemas/post.ts
@@ -36,9 +36,10 @@ export type PostListItem = z.infer<typeof PostListItemSchema>
 
 // Schema for full post (includes blocks and all metadata)
 // Used for validating cached post data
-// Note: blocks are typed as unknown for cache validation since they're validated separately
 export const PostSchema = PostListItemSchema.extend({
-  blocks: z.array(z.unknown()), // Validated separately in getBlockChildren
+  // Blocks are stored as unknown[] in cache for flexibility,
+  // and are validated separately during fetching (see getBlockChildren)
+  blocks: z.array(z.unknown()),
   lastEditedTime: z.string(),
   prevPost: PostListItemSchema.nullable(),
   nextPost: PostListItemSchema.nullable(),

--- a/lib/tmdb/fetchTmdbList.ts
+++ b/lib/tmdb/fetchTmdbList.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 import transformCloudinaryImage from '@/lib/cloudinary/transformCloudinaryImage'
 import getImagePlaceholderForEnv from '@/utils/getImagePlaceholderForEnv'
+import { formatValidationError } from '@/utils/zod'
 import { env } from '@/lib/env'
 import { type Result, Ok, Err, toErr } from '@/utils/result'
 
@@ -63,7 +64,7 @@ export default async function fetchTmdbList(listId: string, api: 'tv' | 'movie')
           // Validate raw TMDB data at API boundary
           const parsedResult = TmdbApiResultSchema.safeParse(result)
           if (!parsedResult.success) {
-            console.log('Skipping invalid TMDB result:', parsedResult.error.format())
+            console.log('Skipping invalid TMDB result:', formatValidationError(parsedResult.error))
             continue
           }
 

--- a/utils/zod.ts
+++ b/utils/zod.ts
@@ -1,10 +1,25 @@
 import { type ZodError } from 'zod'
 
 /**
+ * Formats a Zod validation error into a concise, readable string.
+ * Returns the problematic fields and their error messages.
+ *
+ * @param error - The Zod validation error
+ * @returns Formatted string like "title: Required, date: Invalid format"
+ *
+ * @example
+ * const formatted = formatValidationError(zodError)
+ * // Returns: "title: Required, date: Invalid format"
+ */
+export function formatValidationError(error: ZodError): string {
+  return error.issues.map(issue => `${issue.path.join('.')}: ${issue.message}`).join(', ')
+}
+
+/**
  * Logs a Zod validation error in a concise, readable format.
  * Example: "Skipping invalid post (title: Required, date: Invalid format)"
  */
 export function logValidationError(error: ZodError, context: string): void {
-  const errors = error.issues.map(issue => `${issue.path.join('.')}: ${issue.message}`).join(', ')
+  const errors = formatValidationError(error)
   console.warn(`Skipping invalid ${context} (${errors})`)
 }


### PR DESCRIPTION
## ✅ What

- Validates Cloudinary API responses with Zod (catches invalid structure like missing width/height or wrong types)
- Validates cached data when reading from filesystem (detects corrupted cache files, handles schema evolution)
- Refactors Cloudinary image metadata fetching to extract URL generation into a pure, testable helper function
- Updates all Notion cache reads to validate with their schemas
- Adds comprehensive test suite for cache validation (12 tests)
- Documents the input validation pattern in `.claude/specs/input-validation-pattern.md`

## 🤔 Why

- **Prevents runtime errors**: Corrupted cache files or unexpected API responses now fail gracefully with helpful error messages instead of crashing at runtime
- **Handles schema evolution**: When data structures change, invalid cached data is automatically rejected and re-fetched rather than causing bugs
- **Makes validation explicit**: Clear pattern documented for future external inputs (APIs, file reads, etc.)
- **Improves maintainability**: Extracted `generateResponsiveImageUrls()` helper is pure and easily testable in isolation

## 📊 Coverage

- All external inputs now validated (environment vars, TMDB, iTunes, Notion, Cloudinary, cache)
- 212 tests passing (added 23 new tests)
- 100% TypeScript compliance
- Zero unsafe type assertions on external data

## 🔍 Pattern Highlights

**Cache validation** - schemas now required:
```typescript
// ✅ Safe - validates cached data
const cached = await cache.get('posts', 'notion', z.array(PostListItemSchema))

// ⚠️ Unsafe - no validation (still works but not recommended)
const cached = await cache.get('posts', 'notion')
```

**API validation** - catches malformed responses:
```typescript
const parseResult = CloudinaryResourceSchema.safeParse(response)
if (!parseResult.success) {
  throw new Error(`Invalid API response: ${parseResult.error.message}`)
}
```

See `.claude/specs/input-validation-pattern.md` for full guidance.