### PR TITLE
Fill build-time testing gaps

### DIFF
--- a/.claude/specs/build-integration-tests-plan.md
+++ b/.claude/specs/build-integration-tests-plan.md
@@ -1,0 +1,314 @@
+# Build Integration Tests Plan
+
+**Date**: 2025-12-13
+**Status**: Planning
+**Branch**: To be implemented after `fill-testing-gaps` is merged
+
+## Overview
+
+This plan adds **build integration tests** that verify the actual Next.js build process succeeds. Unlike unit tests that mock dependencies, these tests run `next build` and validate the output.
+
+## Goals
+
+1. **Verify builds succeed**: Ensure `next build` completes without errors
+2. **Catch build-time failures**: Detect issues that only appear during actual builds
+3. **Validate static generation**: Confirm all expected pages are pre-rendered
+4. **Monitor build warnings**: Ensure no unexpected warnings appear
+5. **Test cache invalidation**: Verify `nocache=true` query param works
+
+## Non-Goals
+
+- Not replacing unit tests (those stay - faster feedback loop)
+- Not testing runtime behavior (that's E2E testing)
+- Not running on every commit (too slow - run in CI only)
+
+## Implementation Strategy
+
+### 1. Test Framework Setup
+
+**File**: `tests/build/setup.ts`
+
+Create a test harness that:
+- Runs `next build` in a child process
+- Captures stdout/stderr
+- Parses build output for errors/warnings
+- Validates `.next` directory structure
+- Cleans up after tests
+
+**Dependencies needed**:
+```json
+{
+  "execa": "^8.0.0" // For running shell commands with proper stdio handling
+}
+```
+
+### 2. Core Build Tests
+
+**File**: `tests/build/next-build.test.ts`
+
+#### Test Cases:
+
+1. **Build succeeds without errors**
+   - Run `next build`
+   - Assert exit code is 0
+   - Assert no error messages in output
+
+2. **All expected pages are generated**
+   - Verify `.next/server/app/(prose)/[slug]/` contains HTML files
+   - Verify `.next/server/app/(prose)/blog.html` exists
+   - Verify `.next/server/app/likes.html` exists
+   - Count matches expected number of blog posts
+
+3. **Static params generate all routes**
+   - Parse build output for "generating static pages"
+   - Verify count matches number of posts
+   - Verify specific known slugs appear
+
+4. **No unexpected build warnings**
+   - Parse stdout for warning patterns
+   - Allow known/acceptable warnings (if any)
+   - Fail on unexpected warnings (e.g., missing env vars, deprecated APIs)
+
+5. **Build artifacts are valid**
+   - Verify `.next/BUILD_ID` exists and is non-empty
+   - Verify `.next/required-server-files.json` exists
+   - Verify client bundles exist in `.next/static/`
+
+### 3. Cache Invalidation Tests
+
+**File**: `tests/build/cache-behavior.test.ts`
+
+#### Test Cases:
+
+1. **Cache is used in development**
+   - Mock Notion API responses
+   - Run two builds
+   - Verify second build uses cached data (faster)
+   - Verify cache files exist in `.local-cache/`
+
+2. **Cache is bypassed in production**
+   - Set NODE_ENV=production
+   - Verify no cache reads/writes
+   - Verify `.local-cache/` is not used
+
+3. **skipCache query param works**
+   - Test would need to verify builds with different cache behavior
+   - (This might be more of a runtime test - consider scope)
+
+### 4. Error Scenario Tests
+
+**File**: `tests/build/error-handling.test.ts`
+
+#### Test Cases:
+
+1. **Build fails when API returns error**
+   - Mock Notion API to return 500
+   - Run build
+   - Assert build fails with helpful error message
+   - Verify error shows which API failed
+
+2. **Build fails when validation fails**
+   - Mock Notion API to return invalid data
+   - Run build
+   - Assert build fails with validation error
+   - Verify error shows which field failed validation
+
+3. **Build fails when env vars missing**
+   - Unset required env var
+   - Run build
+   - Assert build fails with clear error about missing env var
+
+4. **Build fails when getPost returns null for invalid slug**
+   - This should trigger `notFound()` which is expected
+   - Build should still succeed
+   - (This validates the happy path of error handling)
+
+### 5. Performance Monitoring (Optional)
+
+**File**: `tests/build/performance.test.ts`
+
+#### Test Cases:
+
+1. **Build completes within reasonable time**
+   - Run build with timer
+   - Assert completes within threshold (e.g., 2 minutes)
+   - Track build time in CI for regression detection
+
+2. **Parallel API calls work efficiently**
+   - Monitor that likes page fetches all 5 APIs in parallel
+   - Verify build time reflects parallelization
+
+### 6. CI Integration
+
+**File**: `.github/workflows/build-tests.yml`
+
+```yaml
+name: Build Integration Tests
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm test -- --run
+
+      - name: Run build integration tests
+        run: npm run test:build
+        env:
+          NODE_ENV: production
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+          NOTION_BLOG_DATABASE_ID: ${{ secrets.NOTION_BLOG_DATABASE_ID }}
+          # ... all required env vars
+
+      - name: Upload build artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-output
+          path: .next/
+```
+
+**Note**: This requires secrets to be set in GitHub repository settings.
+
+## Test Isolation Strategy
+
+### Challenge: External API Dependencies
+
+Build tests call real APIs (Notion, TMDB, iTunes). Options:
+
+**Option A: Use Real APIs (Recommended for first iteration)**
+- Pros: Tests real integration, catches API changes
+- Cons: Slower, requires API credentials in CI, subject to rate limits
+- Mitigation: Run less frequently (only on PR/main), use caching where possible
+
+**Option B: Mock at Network Level**
+- Use MSW (Mock Service Worker) or nock to intercept HTTP requests
+- Pros: Fast, deterministic, no API credentials needed
+- Cons: Doesn't catch API changes, more setup overhead
+
+**Option C: Hybrid Approach**
+- Unit tests: Mock everything (fast feedback)
+- Build tests: Real APIs (comprehensive validation)
+- Best of both worlds
+
+**Recommendation**: Start with Option A for simplicity. If builds become too slow or flaky, move to Option C.
+
+## Directory Structure
+
+```
+tests/
+├── build/
+│   ├── setup.ts              # Build harness utilities
+│   ├── next-build.test.ts    # Core build tests
+│   ├── cache-behavior.test.ts
+│   ├── error-handling.test.ts
+│   └── performance.test.ts   # Optional
+├── fixtures/                  # Mock data if needed
+└── README.md                  # How to run build tests
+```
+
+## NPM Scripts
+
+Add to `package.json`:
+
+```json
+{
+  "scripts": {
+    "test": "vitest",
+    "test:unit": "vitest --run",
+    "test:build": "NODE_ENV=test vitest --run tests/build",
+    "test:all": "npm run test:unit && npm run test:build"
+  }
+}
+```
+
+## Implementation Order
+
+1. **Phase 1: Basic Setup** (1-2 hours)
+   - Install dependencies (execa)
+   - Create test harness in `tests/build/setup.ts`
+   - Write first test: "build succeeds without errors"
+   - Verify it runs and passes
+
+2. **Phase 2: Core Validation** (2-3 hours)
+   - Test all expected pages are generated
+   - Test static params generate all routes
+   - Test no unexpected warnings
+   - Test build artifacts are valid
+
+3. **Phase 3: Error Scenarios** (2-3 hours)
+   - Test build fails when API returns error
+   - Test build fails when validation fails
+   - Test build fails when env vars missing
+
+4. **Phase 4: CI Integration** (1 hour)
+   - Create GitHub workflow
+   - Add secrets to repository
+   - Verify workflow runs on PR
+
+5. **Phase 5: Polish** (1 hour)
+   - Add README documentation
+   - Update analysis document
+   - Add performance monitoring (optional)
+
+**Total estimated effort**: 6-10 hours
+
+## Success Criteria
+
+- [ ] Can run `npm run test:build` locally
+- [ ] Build tests pass with real API calls
+- [ ] Build tests fail appropriately when errors injected
+- [ ] CI runs build tests on every PR
+- [ ] Build test failures provide actionable error messages
+- [ ] Documentation explains how to run and interpret build tests
+
+## Edge Cases to Consider
+
+1. **Rate Limiting**: TMDB/iTunes APIs may rate limit in CI
+   - Mitigation: Add retry logic, use caching, or mock these specific APIs
+
+2. **Notion API Pagination**: If blog grows beyond 100 posts
+   - Mitigation: Already handled in code, but verify build doesn't timeout
+
+3. **Build Output Size**: Large blogs may produce many files
+   - Mitigation: Add cleanup step to CI, monitor disk usage
+
+4. **Flaky Tests**: Network issues may cause intermittent failures
+   - Mitigation: Add retries, better error messages, consider mocking flaky APIs
+
+5. **Parallel Builds**: Multiple builds running simultaneously may conflict
+   - Mitigation: Use separate output directories per test run
+
+## Future Enhancements
+
+After initial implementation, consider:
+
+1. **Visual Regression Tests**: Screenshot generated pages, compare to baseline
+2. **Performance Benchmarks**: Track build time trends over time
+3. **Bundle Size Monitoring**: Alert if bundle size increases significantly
+4. **Lighthouse Scores**: Run Lighthouse on generated pages
+5. **Link Checking**: Verify all internal links resolve correctly
+
+## References
+
+- [Next.js Build Output](https://nextjs.org/docs/app/api-reference/next-config-js/output)
+- [Vitest Node Test Examples](https://vitest.dev/guide/environment.html#test-environment)
+- [GitHub Actions - Artifacts](https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts)

--- a/.claude/specs/build-integration-tests-plan.md
+++ b/.claude/specs/build-integration-tests-plan.md
@@ -29,6 +29,7 @@ This plan adds **build integration tests** that verify the actual Next.js build 
 **File**: `tests/build/setup.ts`
 
 Create a test harness that:
+
 - Runs `next build` in a child process
 - Captures stdout/stderr
 - Parses build output for errors/warnings
@@ -36,6 +37,7 @@ Create a test harness that:
 - Cleans up after tests
 
 **Dependencies needed**:
+
 ```json
 {
   "execa": "^8.0.0" // For running shell commands with proper stdio handling
@@ -195,16 +197,19 @@ jobs:
 Build tests call real APIs (Notion, TMDB, iTunes). Options:
 
 **Option A: Use Real APIs (Recommended for first iteration)**
+
 - Pros: Tests real integration, catches API changes
 - Cons: Slower, requires API credentials in CI, subject to rate limits
 - Mitigation: Run less frequently (only on PR/main), use caching where possible
 
 **Option B: Mock at Network Level**
+
 - Use MSW (Mock Service Worker) or nock to intercept HTTP requests
 - Pros: Fast, deterministic, no API credentials needed
 - Cons: Doesn't catch API changes, more setup overhead
 
 **Option C: Hybrid Approach**
+
 - Unit tests: Mock everything (fast feedback)
 - Build tests: Real APIs (comprehensive validation)
 - Best of both worlds

--- a/.claude/specs/build-time-testing-gaps-analysis.md
+++ b/.claude/specs/build-time-testing-gaps-analysis.md
@@ -178,7 +178,7 @@ This document identifies testing gaps in the build-time logic of the Next.js app
 | Build-Time Component | Unit Tests | Integration Tests | E2E/Build Tests |
 |---------------------|------------|-------------------|-----------------|
 | `generateStaticParams` | ✅ **Complete** (6 tests) | ❌ None | ❌ None |
-| Page components (Server Components) | ⚠️ Partial (1/4) | ❌ None | ❌ None |
+| Page components (Server Components) | ⚠️ Partial (14/20+ tests) | ❌ None | ❌ None |
 | Notion API fetching | ✅ Excellent (26 tests) | ⚠️ Mocked | ❌ None |
 | TMDB API fetching | ✅ Good (13 tests) | ❌ None | ❌ None |
 | iTunes API fetching | ✅ Good (10 tests) | ❌ None | ❌ None |
@@ -238,3 +238,17 @@ Work through the priority list one test at a time:
 1. Page component integration tests (Server Components)
 2. Image placeholder error handling improvements
 3. Build-time error reporting enhancements
+
+### 2025-12-13 - Session 2
+
+**Completed:**
+3. ✅ **Blog page component** - Created `app/(prose)/blog/page.test.tsx`
+   - 8 comprehensive tests for Server Component build-time behavior
+   - Tests successful data fetching with descending sort
+   - Tests skipCache query param handling (`nocache=true`)
+   - Tests empty posts array handling
+   - Tests component structure and rendering
+   - Tests error propagation (build failures when data fetch fails)
+   - All tests passing
+
+**Updated Test Count:** 254 tests total (was 246)

--- a/.claude/specs/build-time-testing-gaps-analysis.md
+++ b/.claude/specs/build-time-testing-gaps-analysis.md
@@ -178,7 +178,7 @@ This document identifies testing gaps in the build-time logic of the Next.js app
 | Build-Time Component | Unit Tests | Integration Tests | E2E/Build Tests |
 |---------------------|------------|-------------------|-----------------|
 | `generateStaticParams` | ✅ **Complete** (6 tests) | ❌ None | ❌ None |
-| Page components (Server Components) | ⚠️ Good (22 tests - blog + dynamic route) | ❌ None | ❌ None |
+| Page components (Server Components) | ✅ **Excellent** (32 tests - all major pages) | ❌ None | ❌ None |
 | Notion API fetching | ✅ Excellent (26 tests) | ⚠️ Mocked | ❌ None |
 | TMDB API fetching | ✅ Good (13 tests) | ❌ None | ❌ None |
 | iTunes API fetching | ✅ Good (10 tests) | ❌ None | ❌ None |
@@ -266,3 +266,18 @@ Work through the priority list one test at a time:
    - All tests passing
 
 **Updated Test Count:** 262 tests total (was 254)
+
+### 2025-12-13 - Session 4
+
+**Completed:**
+5. ✅ **Likes page component** - Extended `app/likes/page.test.tsx`
+   - 10 additional tests for the page component's default export
+   - Tests parallel fetching of all 5 media types (TV, movies, books, albums, podcasts)
+   - Tests skipCache query param handling for iTunes media
+   - Tests empty responses from all APIs
+   - Tests error propagation when any of the 5 API calls fail during build
+   - Tests that build fails fast when Promise.all encounters error
+   - Total tests in file: 16 (6 helper + 10 page component)
+   - All tests passing
+
+**Updated Test Count:** 272 tests total (was 262)

--- a/.claude/specs/build-time-testing-gaps-analysis.md
+++ b/.claude/specs/build-time-testing-gaps-analysis.md
@@ -177,16 +177,16 @@ This document identifies testing gaps in the build-time logic of the Next.js app
 
 | Build-Time Component | Unit Tests | Integration Tests | E2E/Build Tests |
 |---------------------|------------|-------------------|-----------------|
-| `generateStaticParams` | ❌ None | ❌ None | ❌ None |
+| `generateStaticParams` | ✅ **Complete** (6 tests) | ❌ None | ❌ None |
 | Page components (Server Components) | ⚠️ Partial (1/4) | ❌ None | ❌ None |
-| Notion API fetching | ✅ Excellent | ⚠️ Mocked | ❌ None |
-| TMDB API fetching | ✅ Good | ❌ None | ❌ None |
-| iTunes API fetching | ✅ Good | ❌ None | ❌ None |
-| Cloudinary metadata | ✅ Good | ❌ None | ❌ None |
-| Image placeholders | ⚠️ Mocked | ❌ None | ❌ None |
-| Caching | ✅ Good | ❌ None | ❌ None |
-| Environment validation | ❌ None | ❌ None | ❌ None |
-| Block fetching | ❌ None | ❌ None | ❌ None |
+| Notion API fetching | ✅ Excellent (26 tests) | ⚠️ Mocked | ❌ None |
+| TMDB API fetching | ✅ Good (13 tests) | ❌ None | ❌ None |
+| iTunes API fetching | ✅ Good (10 tests) | ❌ None | ❌ None |
+| Cloudinary metadata | ✅ Good (15 tests) | ❌ None | ❌ None |
+| Image placeholders | ⚠️ Mocked (5 tests) | ❌ None | ❌ None |
+| Caching | ✅ Good (12 tests) | ❌ None | ❌ None |
+| Environment validation | ✅ **Complete** (28 tests) | ❌ None | ❌ None |
+| Block fetching | ✅ Excellent (26 tests) | ❌ None | ❌ None |
 | Error handling/recovery | ⚠️ Partial | ❌ None | ❌ None |
 
 ## Priority Order
@@ -211,3 +211,30 @@ Work through the priority list one test at a time:
 - Test both success and error paths
 - Verify error messages are helpful
 - Ensure tests follow existing patterns in the codebase
+
+## Progress Log
+
+### 2025-12-13 - Session 1
+
+**Completed:**
+1. ✅ **`generateStaticParams`** - Created `app/(prose)/[slug]/page.test.tsx`
+   - 6 comprehensive tests covering success and error cases
+   - Tests verify correct params structure for Next.js
+   - Tests verify build failures are explicit when data fetching fails
+   - Tests verify empty post lists are handled gracefully
+   - All tests passing
+
+2. ✅ **Environment validation** - Created `lib/env.test.ts`
+   - 28 comprehensive tests covering all required env vars
+   - Tests for missing variables (TMDB, Notion, Cloudinary)
+   - Tests for empty string validation
+   - Tests for Zod error message structure
+   - Tests verify multiple missing vars are reported at once
+   - All tests passing
+
+**Updated Test Count:** 246 tests total (was 218)
+
+**Next Priorities:**
+1. Page component integration tests (Server Components)
+2. Image placeholder error handling improvements
+3. Build-time error reporting enhancements

--- a/.claude/specs/build-time-testing-gaps-analysis.md
+++ b/.claude/specs/build-time-testing-gaps-analysis.md
@@ -178,7 +178,7 @@ This document identifies testing gaps in the build-time logic of the Next.js app
 | Build-Time Component | Unit Tests | Integration Tests | E2E/Build Tests |
 |---------------------|------------|-------------------|-----------------|
 | `generateStaticParams` | ✅ **Complete** (6 tests) | ❌ None | ❌ None |
-| Page components (Server Components) | ⚠️ Partial (14/20+ tests) | ❌ None | ❌ None |
+| Page components (Server Components) | ⚠️ Good (22 tests - blog + dynamic route) | ❌ None | ❌ None |
 | Notion API fetching | ✅ Excellent (26 tests) | ⚠️ Mocked | ❌ None |
 | TMDB API fetching | ✅ Good (13 tests) | ❌ None | ❌ None |
 | iTunes API fetching | ✅ Good (10 tests) | ❌ None | ❌ None |
@@ -252,3 +252,17 @@ Work through the priority list one test at a time:
    - All tests passing
 
 **Updated Test Count:** 254 tests total (was 246)
+
+### 2025-12-13 - Session 3
+
+**Completed:**
+4. ✅ **Dynamic route page component** - Extended `app/(prose)/[slug]/page.test.tsx`
+   - 8 additional tests for the page component's default export
+   - Tests successful post fetching with blocks and navigation
+   - Tests skipCache query param handling
+   - Tests `notFound()` behavior when post doesn't exist
+   - Tests error propagation (build failures when getPost fails)
+   - Total tests in file: 14 (6 generateStaticParams + 8 page component)
+   - All tests passing
+
+**Updated Test Count:** 262 tests total (was 254)

--- a/.claude/specs/build-time-testing-gaps-analysis.md
+++ b/.claude/specs/build-time-testing-gaps-analysis.md
@@ -281,3 +281,25 @@ Work through the priority list one test at a time:
    - All tests passing
 
 **Updated Test Count:** 272 tests total (was 262)
+
+### 2025-12-13 - Session 5
+
+**Completed:**
+6. ✅ **Zod validation error utilities** - Created `utils/zod.test.ts`
+   - 21 comprehensive tests for `formatValidationError` and `logValidationError`
+   - Tests single field errors (required, type mismatch, email, min length, regex)
+   - Tests nested field errors with dot notation (objects, arrays, deep nesting)
+   - Tests multiple field errors with comma separation and order preservation
+   - Tests empty path errors (root-level validation)
+   - Tests real-world scenarios (Notion posts, media items)
+   - Tests logging functionality (console.warn usage, message format, context handling)
+   - Tests build-time debugging helpfulness (concise messages, no throw behavior)
+   - All tests passing
+
+**Updated Test Count:** 303 tests total (was 272)
+
+**Build-Time Testing Status:**
+- ✅ All critical and high-priority gaps filled
+- ✅ Most medium-priority gaps filled (image placeholder error handling, validation utilities)
+- ⚠️ Remaining gaps: Cloudinary transformation tests (5 basic tests exist)
+- 🎯 Test suite now provides comprehensive build-time validation coverage

--- a/app/(prose)/[slug]/page.test.tsx
+++ b/app/(prose)/[slug]/page.test.tsx
@@ -1,0 +1,105 @@
+import { generateStaticParams } from './page'
+import getPosts from '@/lib/notion/getPosts'
+import { Ok, Err } from '@/utils/result'
+
+// Mock dependencies
+vi.mock('@/lib/notion/getPosts')
+
+describe('generateStaticParams', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('success cases', () => {
+    it('returns array of slug params for all posts', async () => {
+      const mockPosts = [
+        {
+          id: '1',
+          slug: 'first-post',
+          title: 'First Post',
+          description: 'Description 1',
+          firstPublished: '2024-01-01',
+          featuredImage: null,
+        },
+        {
+          id: '2',
+          slug: 'second-post',
+          title: 'Second Post',
+          description: 'Description 2',
+          firstPublished: '2024-01-02',
+          featuredImage: null,
+        },
+        {
+          id: '3',
+          slug: 'third-post',
+          title: 'Third Post',
+          description: 'Description 3',
+          firstPublished: '2024-01-03',
+          featuredImage: null,
+        },
+      ]
+
+      vi.mocked(getPosts).mockResolvedValue(Ok(mockPosts))
+
+      const result = await generateStaticParams()
+
+      expect(result).toEqual([{ slug: 'first-post' }, { slug: 'second-post' }, { slug: 'third-post' }])
+    })
+
+    it('calls getPosts with ascending sort direction', async () => {
+      vi.mocked(getPosts).mockResolvedValue(Ok([]))
+
+      await generateStaticParams()
+
+      expect(getPosts).toHaveBeenCalledWith({ sortDirection: 'ascending' })
+    })
+
+    it('returns empty array when no posts exist', async () => {
+      vi.mocked(getPosts).mockResolvedValue(Ok([]))
+
+      const result = await generateStaticParams()
+
+      expect(result).toEqual([])
+    })
+
+    it('returns correct params structure for Next.js', async () => {
+      const mockPosts = [
+        {
+          id: '1',
+          slug: 'test-slug',
+          title: 'Test',
+          description: null,
+          firstPublished: '2024-01-01',
+          featuredImage: null,
+        },
+      ]
+
+      vi.mocked(getPosts).mockResolvedValue(Ok(mockPosts))
+
+      const result = await generateStaticParams()
+
+      // Verify structure matches Next.js expectation
+      expect(result).toBeInstanceOf(Array)
+      expect(result[0]).toHaveProperty('slug')
+      expect(typeof result[0].slug).toBe('string')
+      expect(Object.keys(result[0])).toEqual(['slug'])
+    })
+  })
+
+  describe('error cases', () => {
+    it('throws when getPosts returns Err', async () => {
+      const error = new Error('Failed to fetch posts from Notion')
+      vi.mocked(getPosts).mockResolvedValue(Err(error))
+
+      // The .unwrap() call in generateStaticParams should throw
+      await expect(generateStaticParams()).rejects.toThrow('Failed to fetch posts from Notion')
+    })
+
+    it('throws when getPosts rejects', async () => {
+      const error = new Error('Network error')
+      vi.mocked(getPosts).mockRejectedValue(error)
+
+      await expect(generateStaticParams()).rejects.toThrow('Network error')
+    })
+  })
+})

--- a/app/(prose)/[slug]/page.test.tsx
+++ b/app/(prose)/[slug]/page.test.tsx
@@ -1,3 +1,7 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
 import { render, screen } from '@testing-library/react'
 import { generateStaticParams } from './page'
 import DynamicRoute from './page'

--- a/app/(prose)/[slug]/page.test.tsx
+++ b/app/(prose)/[slug]/page.test.tsx
@@ -254,8 +254,8 @@ describe('DynamicRoute page', () => {
       expect(notFound).toHaveBeenCalled()
     })
 
-    it('calls notFound() when post is undefined', async () => {
-      vi.mocked(getPost).mockResolvedValue(Ok(undefined as any))
+    it('calls notFound() when post does not exist', async () => {
+      vi.mocked(getPost).mockResolvedValue(Ok(null))
       vi.mocked(notFound).mockImplementation(() => {
         throw new Error('NEXT_NOT_FOUND')
       })

--- a/app/(prose)/blog/page.test.tsx
+++ b/app/(prose)/blog/page.test.tsx
@@ -1,0 +1,163 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import Blog from './page'
+import getPosts from '@/lib/notion/getPosts'
+import { Ok, Err } from '@/utils/result'
+
+// Mock dependencies
+vi.mock('@/lib/notion/getPosts')
+
+describe('Blog page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('success cases', () => {
+    it('fetches and renders posts with descending sort', async () => {
+      const mockPosts = [
+        {
+          id: '1',
+          slug: 'newest-post',
+          title: 'Newest Post',
+          description: 'Most recent',
+          firstPublished: '2024-03-15',
+          featuredImage: null,
+        },
+        {
+          id: '2',
+          slug: 'older-post',
+          title: 'Older Post',
+          description: 'Earlier post',
+          firstPublished: '2024-01-15',
+          featuredImage: null,
+        },
+      ]
+
+      vi.mocked(getPosts).mockResolvedValue(Ok(mockPosts))
+
+      const searchParams = Promise.resolve({})
+      const result = await Blog({ searchParams })
+
+      expect(getPosts).toHaveBeenCalledWith({ sortDirection: 'descending', skipCache: false })
+      expect(result.type).toBe('main')
+      expect(result.props.children).toBeDefined()
+    })
+
+    it('passes skipCache=true when nocache query param is present', async () => {
+      const mockPosts = [
+        {
+          id: '1',
+          slug: 'test-post',
+          title: 'Test Post',
+          description: null,
+          firstPublished: '2024-01-15',
+          featuredImage: null,
+        },
+      ]
+
+      vi.mocked(getPosts).mockResolvedValue(Ok(mockPosts))
+
+      const searchParams = Promise.resolve({ nocache: 'true' })
+      await Blog({ searchParams })
+
+      expect(getPosts).toHaveBeenCalledWith({ sortDirection: 'descending', skipCache: true })
+    })
+
+    it('passes skipCache=false when nocache is not "true"', async () => {
+      const mockPosts = []
+
+      vi.mocked(getPosts).mockResolvedValue(Ok(mockPosts))
+
+      const searchParams = Promise.resolve({ nocache: 'false' })
+      await Blog({ searchParams })
+
+      expect(getPosts).toHaveBeenCalledWith({ sortDirection: 'descending', skipCache: false })
+    })
+
+    it('handles empty posts array gracefully', async () => {
+      vi.mocked(getPosts).mockResolvedValue(Ok([]))
+
+      const searchParams = Promise.resolve({})
+      const result = await Blog({ searchParams })
+
+      expect(result.type).toBe('main')
+      expect(result.props.children).toBeDefined()
+    })
+
+    it('renders posts with correct structure', async () => {
+      const mockPosts = [
+        {
+          id: '123',
+          slug: 'test-post',
+          title: 'Test Post Title',
+          description: 'Test description',
+          firstPublished: '2024-01-15',
+          featuredImage: null,
+        },
+      ]
+
+      vi.mocked(getPosts).mockResolvedValue(Ok(mockPosts))
+
+      const searchParams = Promise.resolve({})
+      const result = await Blog({ searchParams })
+
+      // Verify the component structure
+      expect(result.type).toBe('main')
+      expect(result.props.className).toBe('flex-auto')
+
+      // Find the posts list in the rendered output
+      const mainChildren = result.props.children
+      expect(Array.isArray(mainChildren)).toBe(true)
+
+      // Verify heading exists
+      const heading = mainChildren[0]
+      expect(heading.props.level).toBe(1)
+
+      // Verify posts list exists
+      const postsList = mainChildren[1]
+      expect(postsList.type).toBe('ul')
+      expect(postsList.props.className).toBe('mt-8 grid gap-8')
+    })
+
+    it('uses slug as fallback when title is missing', async () => {
+      const mockPosts = [
+        {
+          id: '1',
+          slug: 'fallback-slug',
+          title: '', // Empty title
+          description: null,
+          firstPublished: '2024-01-15',
+          featuredImage: null,
+        },
+      ]
+
+      vi.mocked(getPosts).mockResolvedValue(Ok(mockPosts))
+
+      const searchParams = Promise.resolve({})
+      const result = await Blog({ searchParams })
+
+      // The component should still render without error
+      expect(result.type).toBe('main')
+    })
+  })
+
+  describe('error cases', () => {
+    it('throws when getPosts returns Err', async () => {
+      const error = new Error('Failed to fetch posts from Notion')
+      vi.mocked(getPosts).mockResolvedValue(Err(error))
+
+      const searchParams = Promise.resolve({})
+
+      // The .unwrap() call should throw, causing build to fail
+      await expect(Blog({ searchParams })).rejects.toThrow('Failed to fetch posts from Notion')
+    })
+
+    it('throws when getPosts rejects', async () => {
+      const error = new Error('Network error')
+      vi.mocked(getPosts).mockRejectedValue(error)
+
+      const searchParams = Promise.resolve({})
+
+      await expect(Blog({ searchParams })).rejects.toThrow('Network error')
+    })
+  })
+})

--- a/app/(prose)/blog/page.test.tsx
+++ b/app/(prose)/blog/page.test.tsx
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
+import type { ReactElement } from 'react'
 import Blog from './page'
 import getPosts from '@/lib/notion/getPosts'
+import type { PostListItem } from '@/lib/notion/schemas/post'
 import { Ok, Err } from '@/utils/result'
 
 // Mock dependencies
@@ -13,7 +15,7 @@ describe('Blog page', () => {
 
   describe('success cases', () => {
     it('fetches and renders posts with descending sort', async () => {
-      const mockPosts = [
+      const mockPosts: PostListItem[] = [
         {
           id: '1',
           slug: 'newest-post',
@@ -35,11 +37,11 @@ describe('Blog page', () => {
       vi.mocked(getPosts).mockResolvedValue(Ok(mockPosts))
 
       const searchParams = Promise.resolve({})
-      const result = await Blog({ searchParams })
+      const result = (await Blog({ searchParams })) as ReactElement
 
       expect(getPosts).toHaveBeenCalledWith({ sortDirection: 'descending', skipCache: false })
       expect(result.type).toBe('main')
-      expect(result.props.children).toBeDefined()
+      expect((result.props as { children: unknown }).children).toBeDefined()
     })
 
     it('passes skipCache=true when nocache query param is present', async () => {
@@ -63,7 +65,7 @@ describe('Blog page', () => {
     })
 
     it('passes skipCache=false when nocache is not "true"', async () => {
-      const mockPosts = []
+      const mockPosts: PostListItem[] = []
 
       vi.mocked(getPosts).mockResolvedValue(Ok(mockPosts))
 
@@ -77,10 +79,10 @@ describe('Blog page', () => {
       vi.mocked(getPosts).mockResolvedValue(Ok([]))
 
       const searchParams = Promise.resolve({})
-      const result = await Blog({ searchParams })
+      const result = (await Blog({ searchParams })) as ReactElement
 
       expect(result.type).toBe('main')
-      expect(result.props.children).toBeDefined()
+      expect((result.props as { children: unknown }).children).toBeDefined()
     })
 
     it('renders posts with correct structure', async () => {
@@ -98,24 +100,24 @@ describe('Blog page', () => {
       vi.mocked(getPosts).mockResolvedValue(Ok(mockPosts))
 
       const searchParams = Promise.resolve({})
-      const result = await Blog({ searchParams })
+      const result = (await Blog({ searchParams })) as ReactElement
 
       // Verify the component structure
       expect(result.type).toBe('main')
-      expect(result.props.className).toBe('flex-auto')
+      expect((result.props as { className: string }).className).toBe('flex-auto')
 
       // Find the posts list in the rendered output
-      const mainChildren = result.props.children
+      const mainChildren = (result.props as { children: ReactElement[] }).children
       expect(Array.isArray(mainChildren)).toBe(true)
 
       // Verify heading exists
       const heading = mainChildren[0]
-      expect(heading.props.level).toBe(1)
+      expect((heading.props as { level: number }).level).toBe(1)
 
       // Verify posts list exists
       const postsList = mainChildren[1]
       expect(postsList.type).toBe('ul')
-      expect(postsList.props.className).toBe('mt-8 grid gap-8')
+      expect((postsList.props as { className: string }).className).toBe('mt-8 grid gap-8')
     })
 
     it('uses slug as fallback when title is missing', async () => {

--- a/app/(prose)/blog/page.test.tsx
+++ b/app/(prose)/blog/page.test.tsx
@@ -1,3 +1,7 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import Blog from './page'

--- a/app/likes/page.test.tsx
+++ b/app/likes/page.test.tsx
@@ -1,9 +1,9 @@
-import type { ReactElement } from 'react'
+import { render, screen } from '@testing-library/react'
 import { fetchItunesMedia } from './page'
 import Likes from './page'
 import getMediaItems, { type NotionMediaItem } from '@/lib/notion/getMediaItems'
 import fetchItunesItems, { type iTunesItem } from '@/lib/itunes/fetchItunesItems'
-import fetchTmdbList, { type TmdbItem } from '@/lib/tmdb/fetchTmdbList'
+import fetchTmdbList from '@/lib/tmdb/fetchTmdbList'
 import { Ok, Err, isOk, isErr } from '@/utils/result'
 
 // Mock dependencies
@@ -266,7 +266,8 @@ describe('Likes page', () => {
       )
 
       const searchParams = Promise.resolve({})
-      const result = (await Likes({ searchParams })) as ReactElement
+      const jsx = await Likes({ searchParams })
+      render(jsx)
 
       // Verify all fetchers were called
       expect(fetchTmdbList).toHaveBeenCalledWith(expect.any(String), 'tv')
@@ -274,9 +275,19 @@ describe('Likes page', () => {
       expect(getMediaItems).toHaveBeenCalledTimes(3) // books, albums, podcasts
       expect(fetchItunesItems).toHaveBeenCalledTimes(3)
 
-      // Verify component structure
-      expect(result.type).toBe('main')
-      expect((result.props as { className: string }).className).toBe('flex-auto')
+      // Verify page structure
+      expect(screen.getByRole('main')).toBeInTheDocument()
+      expect(screen.getByRole('main')).toHaveClass('flex-auto')
+
+      // Verify heading
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Likes')
+
+      // Verify section headings exist
+      expect(screen.getByRole('heading', { level: 2, name: /tv/i })).toBeInTheDocument()
+      expect(screen.getByRole('heading', { level: 2, name: /movies/i })).toBeInTheDocument()
+      expect(screen.getByRole('heading', { level: 2, name: /books/i })).toBeInTheDocument()
+      expect(screen.getByRole('heading', { level: 2, name: /albums/i })).toBeInTheDocument()
+      expect(screen.getByRole('heading', { level: 2, name: /podcasts/i })).toBeInTheDocument()
     })
 
     it('passes skipCache=true to iTunes fetchers when nocache param is present', async () => {
@@ -286,7 +297,8 @@ describe('Likes page', () => {
       vi.mocked(fetchItunesItems).mockResolvedValue(Ok([]))
 
       const searchParams = Promise.resolve({ nocache: 'true' })
-      await Likes({ searchParams })
+      const jsx = await Likes({ searchParams })
+      render(jsx)
 
       // Verify skipCache was passed to getMediaItems (called by fetchItunesMedia)
       expect(getMediaItems).toHaveBeenCalledWith({ category: 'books', skipCache: true })
@@ -300,7 +312,8 @@ describe('Likes page', () => {
       vi.mocked(fetchItunesItems).mockResolvedValue(Ok([]))
 
       const searchParams = Promise.resolve({ nocache: 'false' })
-      await Likes({ searchParams })
+      const jsx = await Likes({ searchParams })
+      render(jsx)
 
       expect(getMediaItems).toHaveBeenCalledWith({ category: 'books', skipCache: false })
       expect(getMediaItems).toHaveBeenCalledWith({ category: 'albums', skipCache: false })
@@ -313,10 +326,11 @@ describe('Likes page', () => {
       vi.mocked(fetchItunesItems).mockResolvedValue(Ok([]))
 
       const searchParams = Promise.resolve({})
-      const result = (await Likes({ searchParams })) as ReactElement
+      const jsx = await Likes({ searchParams })
+      render(jsx)
 
-      expect(result.type).toBe('main')
-      expect((result.props as { children: unknown }).children).toBeDefined()
+      expect(screen.getByRole('main')).toBeInTheDocument()
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Likes')
     })
   })
 

--- a/app/likes/page.test.tsx
+++ b/app/likes/page.test.tsx
@@ -1,3 +1,7 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
 import { render, screen } from '@testing-library/react'
 import { fetchItunesMedia } from './page'
 import Likes from './page'

--- a/app/likes/page.test.tsx
+++ b/app/likes/page.test.tsx
@@ -22,9 +22,9 @@ describe('fetchItunesMedia', () => {
 
   describe('success cases', () => {
     it('fetches books and enriches with iTunes metadata', async () => {
-      const mockMediaItems = [
-        { appleId: 1, name: 'Book 1', date: '2024-01-15' },
-        { appleId: 2, name: 'Book 2', date: '2024-02-20' },
+      const mockMediaItems: NotionMediaItem[] = [
+        { id: '1', appleId: 1, name: 'Book 1', date: '2024-01-15' },
+        { id: '2', appleId: 2, name: 'Book 2', date: '2024-02-20' },
       ]
 
       const mockItunesItems = [
@@ -46,7 +46,7 @@ describe('fetchItunesMedia', () => {
         },
       ]
 
-      vi.mocked(getMediaItems).mockResolvedValue(Ok(mockMediaItems as unknown as NotionMediaItem[]))
+      vi.mocked(getMediaItems).mockResolvedValue(Ok(mockMediaItems))
       vi.mocked(fetchItunesItems).mockResolvedValue(Ok(mockItunesItems as iTunesItem[]))
 
       const result = await fetchItunesMedia('books', 'ebook', 'ebook', false)
@@ -68,7 +68,7 @@ describe('fetchItunesMedia', () => {
     })
 
     it('fetches albums with correct iTunes parameters', async () => {
-      const mockMediaItems = [{ appleId: 123, name: 'Album 1', date: '2024-03-10' }]
+      const mockMediaItems: NotionMediaItem[] = [{ id: '123', appleId: 123, name: 'Album 1', date: '2024-03-10' }]
 
       const mockItunesItems = [
         {
@@ -82,7 +82,7 @@ describe('fetchItunesMedia', () => {
         },
       ]
 
-      vi.mocked(getMediaItems).mockResolvedValue(Ok(mockMediaItems as unknown as NotionMediaItem[]))
+      vi.mocked(getMediaItems).mockResolvedValue(Ok(mockMediaItems))
       vi.mocked(fetchItunesItems).mockResolvedValue(Ok(mockItunesItems as iTunesItem[]))
 
       const result = await fetchItunesMedia('albums', 'music', 'album', true)
@@ -97,7 +97,7 @@ describe('fetchItunesMedia', () => {
     })
 
     it('fetches podcasts with correct iTunes parameters', async () => {
-      const mockMediaItems = [{ appleId: 456, name: 'Podcast 1', date: '2024-04-01' }]
+      const mockMediaItems: NotionMediaItem[] = [{ id: '456', appleId: 456, name: 'Podcast 1', date: '2024-04-01' }]
 
       const mockItunesItems = [
         {
@@ -110,7 +110,7 @@ describe('fetchItunesMedia', () => {
         },
       ]
 
-      vi.mocked(getMediaItems).mockResolvedValue(Ok(mockMediaItems as unknown as NotionMediaItem[]))
+      vi.mocked(getMediaItems).mockResolvedValue(Ok(mockMediaItems))
       vi.mocked(fetchItunesItems).mockResolvedValue(Ok(mockItunesItems as iTunesItem[]))
 
       const result = await fetchItunesMedia('podcasts', 'podcast', 'podcast', false)
@@ -142,10 +142,10 @@ describe('fetchItunesMedia', () => {
     })
 
     it('returns Err when fetchItunesItems fails', async () => {
-      const mockMediaItems = [{ appleId: 1, name: 'Book 1', date: '2024-01-15' }]
+      const mockMediaItems: NotionMediaItem[] = [{ id: '1', appleId: 1, name: 'Book 1', date: '2024-01-15' }]
 
       const itunesError = new Error('iTunes API error')
-      vi.mocked(getMediaItems).mockResolvedValue(Ok(mockMediaItems as unknown as NotionMediaItem[]))
+      vi.mocked(getMediaItems).mockResolvedValue(Ok(mockMediaItems))
       vi.mocked(fetchItunesItems).mockResolvedValue(Err(itunesError))
 
       const result = await fetchItunesMedia('books', 'ebook', 'ebook', false)
@@ -159,13 +159,13 @@ describe('fetchItunesMedia', () => {
 
   describe('data transformation', () => {
     it('correctly maps media items to iTunes lookup format', async () => {
-      const mockMediaItems = [
-        { appleId: 111, name: 'Item 1', date: '2024-01-01', otherField: 'ignored' },
-        { appleId: 222, name: 'Item 2', date: '2024-02-02', otherField: 'ignored' },
-        { appleId: 333, name: 'Item 3', date: '2024-03-03', otherField: 'ignored' },
+      const mockMediaItems: NotionMediaItem[] = [
+        { id: '111', appleId: 111, name: 'Item 1', date: '2024-01-01' },
+        { id: '222', appleId: 222, name: 'Item 2', date: '2024-02-02' },
+        { id: '333', appleId: 333, name: 'Item 3', date: '2024-03-03' },
       ]
 
-      vi.mocked(getMediaItems).mockResolvedValue(Ok(mockMediaItems as unknown as NotionMediaItem[]))
+      vi.mocked(getMediaItems).mockResolvedValue(Ok(mockMediaItems))
       vi.mocked(fetchItunesItems).mockResolvedValue(Ok([] as iTunesItem[]))
 
       await fetchItunesMedia('books', 'ebook', 'ebook', false)
@@ -256,8 +256,8 @@ describe('Likes page', () => {
 
       // Mock Notion + iTunes (via fetchItunesMedia helper)
       vi.mocked(getMediaItems).mockImplementation(async () => {
-        const mockMediaItem = { appleId: 999, name: 'Test', date: '2024-01-01' }
-        return Ok([mockMediaItem] as unknown as NotionMediaItem[])
+        const mockMediaItem: NotionMediaItem = { id: '999', appleId: 999, name: 'Test', date: '2024-01-01' }
+        return Ok([mockMediaItem])
       })
 
       vi.mocked(fetchItunesItems).mockImplementation(
@@ -413,10 +413,9 @@ describe('Likes page', () => {
 
     it('throws when iTunes API fails for any category', async () => {
       const error = new Error('iTunes API error')
+      const mockMediaItem: NotionMediaItem = { id: '1', appleId: 1, name: 'Test', date: '2024-01-01' }
       vi.mocked(fetchTmdbList).mockResolvedValue(Ok([]))
-      vi.mocked(getMediaItems).mockResolvedValue(
-        Ok([{ appleId: 1, name: 'Test', date: '2024-01-01' }] as unknown as NotionMediaItem[]),
-      )
+      vi.mocked(getMediaItems).mockResolvedValue(Ok([mockMediaItem]))
       vi.mocked(fetchItunesItems).mockResolvedValue(Err(error))
 
       const searchParams = Promise.resolve({})

--- a/app/likes/page.test.tsx
+++ b/app/likes/page.test.tsx
@@ -1,11 +1,14 @@
 import { fetchItunesMedia } from './page'
+import Likes from './page'
 import getMediaItems, { type NotionMediaItem } from '@/lib/notion/getMediaItems'
 import fetchItunesItems, { type iTunesItem } from '@/lib/itunes/fetchItunesItems'
+import fetchTmdbList from '@/lib/tmdb/fetchTmdbList'
 import { Ok, Err, isOk, isErr } from '@/utils/result'
 
 // Mock dependencies
 vi.mock('@/lib/notion/getMediaItems')
 vi.mock('@/lib/itunes/fetchItunesItems')
+vi.mock('@/lib/tmdb/fetchTmdbList')
 
 describe('fetchItunesMedia', () => {
   beforeEach(() => {
@@ -171,6 +174,231 @@ describe('fetchItunesMedia', () => {
         'ebook',
         'ebook',
       )
+    })
+  })
+})
+
+describe('Likes page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('success cases', () => {
+    it('fetches all media types in parallel during build', async () => {
+      // Mock all API responses
+      const mockTvShows = [
+        {
+          id: 1,
+          title: 'TV Show 1',
+          date: '2024-01-01',
+          imageUrl: 'https://image.tmdb.org/tv1.jpg',
+          imagePlaceholder: 'base64-tv',
+          link: 'https://tmdb.org/tv/1',
+        },
+      ]
+
+      const mockMovies = [
+        {
+          id: 2,
+          title: 'Movie 1',
+          date: '2024-02-01',
+          imageUrl: 'https://image.tmdb.org/movie1.jpg',
+          imagePlaceholder: 'base64-movie',
+          link: 'https://tmdb.org/movie/2',
+        },
+      ]
+
+      const mockBooks = [
+        {
+          id: '3',
+          title: 'Book 1',
+          date: '2024-03-01',
+          imageUrl: 'https://itunes.apple.com/book1.jpg',
+          imagePlaceholder: 'base64-book',
+          link: 'https://books.apple.com/3',
+        },
+      ]
+
+      const mockAlbums = [
+        {
+          id: '4',
+          title: 'Album 1',
+          artist: 'Artist 1',
+          date: '2024-04-01',
+          imageUrl: 'https://itunes.apple.com/album1.jpg',
+          imagePlaceholder: 'base64-album',
+          link: 'https://music.apple.com/4',
+        },
+      ]
+
+      const mockPodcasts = [
+        {
+          id: '5',
+          title: 'Podcast 1',
+          date: '2024-05-01',
+          imageUrl: 'https://itunes.apple.com/podcast1.jpg',
+          imagePlaceholder: 'base64-podcast',
+          link: 'https://podcasts.apple.com/5',
+        },
+      ]
+
+      // Mock TMDB
+      vi.mocked(fetchTmdbList).mockImplementation(async (listId, mediaType) => {
+        if (mediaType === 'tv') return Ok(mockTvShows)
+        if (mediaType === 'movie') return Ok(mockMovies)
+        return Ok([])
+      })
+
+      // Mock Notion + iTunes (via fetchItunesMedia helper)
+      vi.mocked(getMediaItems).mockImplementation(async ({ category }) => {
+        const mockMediaItem = { appleId: 999, name: 'Test', date: '2024-01-01' }
+        return Ok([mockMediaItem] as unknown as NotionMediaItem[])
+      })
+
+      vi.mocked(fetchItunesItems).mockImplementation(async (items, medium) => {
+        if (medium === 'ebook') return Ok(mockBooks as iTunesItem[])
+        if (medium === 'music') return Ok(mockAlbums as iTunesItem[])
+        if (medium === 'podcast') return Ok(mockPodcasts as iTunesItem[])
+        return Ok([])
+      })
+
+      const searchParams = Promise.resolve({})
+      const result = await Likes({ searchParams })
+
+      // Verify all fetchers were called
+      expect(fetchTmdbList).toHaveBeenCalledWith(expect.any(String), 'tv')
+      expect(fetchTmdbList).toHaveBeenCalledWith(expect.any(String), 'movie')
+      expect(getMediaItems).toHaveBeenCalledTimes(3) // books, albums, podcasts
+      expect(fetchItunesItems).toHaveBeenCalledTimes(3)
+
+      // Verify component structure
+      expect(result.type).toBe('main')
+      expect(result.props.className).toBe('flex-auto')
+    })
+
+    it('passes skipCache=true to iTunes fetchers when nocache param is present', async () => {
+      // Mock responses
+      vi.mocked(fetchTmdbList).mockResolvedValue(Ok([]))
+      vi.mocked(getMediaItems).mockResolvedValue(Ok([]))
+      vi.mocked(fetchItunesItems).mockResolvedValue(Ok([]))
+
+      const searchParams = Promise.resolve({ nocache: 'true' })
+      await Likes({ searchParams })
+
+      // Verify skipCache was passed to getMediaItems (called by fetchItunesMedia)
+      expect(getMediaItems).toHaveBeenCalledWith({ category: 'books', skipCache: true })
+      expect(getMediaItems).toHaveBeenCalledWith({ category: 'albums', skipCache: true })
+      expect(getMediaItems).toHaveBeenCalledWith({ category: 'podcasts', skipCache: true })
+    })
+
+    it('passes skipCache=false when nocache is not "true"', async () => {
+      vi.mocked(fetchTmdbList).mockResolvedValue(Ok([]))
+      vi.mocked(getMediaItems).mockResolvedValue(Ok([]))
+      vi.mocked(fetchItunesItems).mockResolvedValue(Ok([]))
+
+      const searchParams = Promise.resolve({ nocache: 'false' })
+      await Likes({ searchParams })
+
+      expect(getMediaItems).toHaveBeenCalledWith({ category: 'books', skipCache: false })
+      expect(getMediaItems).toHaveBeenCalledWith({ category: 'albums', skipCache: false })
+      expect(getMediaItems).toHaveBeenCalledWith({ category: 'podcasts', skipCache: false })
+    })
+
+    it('handles empty responses from all APIs', async () => {
+      vi.mocked(fetchTmdbList).mockResolvedValue(Ok([]))
+      vi.mocked(getMediaItems).mockResolvedValue(Ok([]))
+      vi.mocked(fetchItunesItems).mockResolvedValue(Ok([]))
+
+      const searchParams = Promise.resolve({})
+      const result = await Likes({ searchParams })
+
+      expect(result.type).toBe('main')
+      expect(result.props.children).toBeDefined()
+    })
+  })
+
+  describe('error cases', () => {
+    it('throws when TMDB TV fetch fails', async () => {
+      const error = new Error('TMDB TV API error')
+      vi.mocked(fetchTmdbList).mockImplementation(async (listId, mediaType) => {
+        if (mediaType === 'tv') return Err(error)
+        return Ok([])
+      })
+      vi.mocked(getMediaItems).mockResolvedValue(Ok([]))
+      vi.mocked(fetchItunesItems).mockResolvedValue(Ok([]))
+
+      const searchParams = Promise.resolve({})
+
+      // Promise.all with .unwrap() should throw on first failure
+      await expect(Likes({ searchParams })).rejects.toThrow('TMDB TV API error')
+    })
+
+    it('throws when TMDB movies fetch fails', async () => {
+      const error = new Error('TMDB movies API error')
+      vi.mocked(fetchTmdbList).mockImplementation(async (listId, mediaType) => {
+        if (mediaType === 'tv') return Ok([])
+        if (mediaType === 'movie') return Err(error)
+        return Ok([])
+      })
+      vi.mocked(getMediaItems).mockResolvedValue(Ok([]))
+      vi.mocked(fetchItunesItems).mockResolvedValue(Ok([]))
+
+      const searchParams = Promise.resolve({})
+
+      await expect(Likes({ searchParams })).rejects.toThrow('TMDB movies API error')
+    })
+
+    it('throws when books fetch fails', async () => {
+      const error = new Error('Books fetch failed')
+      vi.mocked(fetchTmdbList).mockResolvedValue(Ok([]))
+      vi.mocked(getMediaItems).mockImplementation(async ({ category }) => {
+        if (category === 'books') return Err(error)
+        return Ok([])
+      })
+      vi.mocked(fetchItunesItems).mockResolvedValue(Ok([]))
+
+      const searchParams = Promise.resolve({})
+
+      await expect(Likes({ searchParams })).rejects.toThrow('Books fetch failed')
+    })
+
+    it('throws when albums fetch fails', async () => {
+      const error = new Error('Albums fetch failed')
+      vi.mocked(fetchTmdbList).mockResolvedValue(Ok([]))
+      vi.mocked(getMediaItems).mockImplementation(async ({ category }) => {
+        if (category === 'albums') return Err(error)
+        return Ok([])
+      })
+      vi.mocked(fetchItunesItems).mockResolvedValue(Ok([]))
+
+      const searchParams = Promise.resolve({})
+
+      await expect(Likes({ searchParams })).rejects.toThrow('Albums fetch failed')
+    })
+
+    it('throws when podcasts fetch fails', async () => {
+      const error = new Error('Podcasts fetch failed')
+      vi.mocked(fetchTmdbList).mockResolvedValue(Ok([]))
+      vi.mocked(getMediaItems).mockImplementation(async ({ category }) => {
+        if (category === 'podcasts') return Err(error)
+        return Ok([])
+      })
+      vi.mocked(fetchItunesItems).mockResolvedValue(Ok([]))
+
+      const searchParams = Promise.resolve({})
+
+      await expect(Likes({ searchParams })).rejects.toThrow('Podcasts fetch failed')
+    })
+
+    it('throws when iTunes API fails for any category', async () => {
+      const error = new Error('iTunes API error')
+      vi.mocked(fetchTmdbList).mockResolvedValue(Ok([]))
+      vi.mocked(getMediaItems).mockResolvedValue(Ok([{ appleId: 1, name: 'Test', date: '2024-01-01' }] as unknown as NotionMediaItem[]))
+      vi.mocked(fetchItunesItems).mockResolvedValue(Err(error))
+
+      const searchParams = Promise.resolve({})
+
+      await expect(Likes({ searchParams })).rejects.toThrow('iTunes API error')
     })
   })
 })

--- a/lib/cloudinary/fetchCloudinaryImageMetadata.ts
+++ b/lib/cloudinary/fetchCloudinaryImageMetadata.ts
@@ -6,6 +6,12 @@ import parsePublicIdFromCloudinaryUrl from './parsePublicIdFromCloudinaryUrl'
 import { Ok, toErr, type Result } from '@/utils/result'
 import { z } from 'zod'
 
+export const ERRORS = {
+  PARSE_PUBLIC_ID_FAILED: (url: string) => `🚨 Could not parse Cloudinary public ID from URL: "${url}"`,
+  INVALID_API_RESPONSE: (publicId: string, errors: string) =>
+    `🚨 Invalid Cloudinary API response for "${publicId}": ${errors}`,
+} as const
+
 export type CloudinaryImageMetadata = {
   alt: string
   caption: string
@@ -110,7 +116,7 @@ export default async function fetchCloudinaryImageMetadata({
   try {
     const publicId = parsePublicIdFromCloudinaryUrl(url)
     if (!publicId) {
-      throw new Error(`🚨 Could not parse Cloudinary public ID from URL: "${url}"`)
+      throw new Error(ERRORS.PARSE_PUBLIC_ID_FAILED(url))
     }
 
     // Check cache first (dev mode only)
@@ -133,7 +139,7 @@ export default async function fetchCloudinaryImageMetadata({
     const parseResult = CloudinaryResourceSchema.safeParse(cloudinaryResponse)
     if (!parseResult.success) {
       const errors = formatValidationError(parseResult.error)
-      throw new Error(`🚨 Invalid Cloudinary API response for "${publicId}": ${errors}`)
+      throw new Error(ERRORS.INVALID_API_RESPONSE(publicId, errors))
     }
 
     const { public_id, width, height, context } = parseResult.data

--- a/lib/cloudinary/parsePublicIdFromCloudinaryUrl.ts
+++ b/lib/cloudinary/parsePublicIdFromCloudinaryUrl.ts
@@ -1,3 +1,10 @@
+export const ERRORS = {
+  NOT_A_STRING: (url: unknown) => `URL must be a string, but was ${typeof url}: ${url}`,
+  NOT_CLOUDINARY_URL: (url: string) => `URL must be a Cloudinary URL, but was: ${url}`,
+  INVALID_FOLDER: (url: string) => `Cloudinary URL image must be in the "mu/" or "fetch/" folders, but was: ${url}`,
+  PARSE_FAILED: (url: string) => `Failed to parse Public ID from Cloudinary URL: ${url}`,
+} as const
+
 /**
  * Parses the public ID from a Cloudinary URL.
  * Assumes the image is stored in the "mu/" or "fetch/" folder.
@@ -13,22 +20,22 @@
  */
 export default function parsePublicIdFromCloudinaryUrl(url: string): string | null {
   if (typeof url !== 'string') {
-    throw new TypeError(`URL must be a string, but was ${typeof url}: ${url}`)
+    throw new TypeError(ERRORS.NOT_A_STRING(url))
   }
 
   if (!url.includes('cloudinary')) {
-    throw new Error(`URL must be a Cloudinary URL, but was: ${url}`)
+    throw new Error(ERRORS.NOT_CLOUDINARY_URL(url))
   }
 
   if (!url.includes('/mu/') && !url.includes('/fetch/')) {
-    throw new Error(`Cloudinary URL image must be in the "mu/" or "fetch/" folders, but was: ${url}`)
+    throw new Error(ERRORS.INVALID_FOLDER(url))
   }
 
   const muPublicIdStart = url.indexOf('/mu/')
   const fetchPublicIdStart = url.indexOf('/fetch/')
 
   if (muPublicIdStart === -1 && fetchPublicIdStart === -1) {
-    throw new Error(`Failed to parse Public ID from Cloudinary URL: ${url}`)
+    throw new Error(ERRORS.PARSE_FAILED(url))
   }
 
   const publicIdStart =

--- a/lib/env.test.ts
+++ b/lib/env.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Unmock the env module so we can test the actual validation logic
+vi.doUnmock('@/lib/env')
+
+describe('env', () => {
+  // Valid environment variables for testing
+  const validEnv = {
+    TMDB_TV_LIST_ID: 'tv-list-123',
+    TMDB_MOVIE_LIST_ID: 'movie-list-456',
+    TMDB_READ_ACCESS_TOKEN: 'tmdb-token-xyz',
+    NOTION_ACCESS_TOKEN: 'notion-token-abc',
+    NOTION_DATA_SOURCE_ID_BOOKS: 'books-db-id',
+    NOTION_DATA_SOURCE_ID_ALBUMS: 'albums-db-id',
+    NOTION_DATA_SOURCE_ID_PODCASTS: 'podcasts-db-id',
+    NOTION_DATA_SOURCE_ID_WRITING: 'writing-db-id',
+    CLOUDINARY_CLOUD_NAME: 'my-cloud',
+    CLOUDINARY_API_KEY: 'cloudinary-key',
+    CLOUDINARY_API_SECRET: 'cloudinary-secret',
+  }
+
+  beforeEach(() => {
+    // Reset modules to allow re-importing with different env vars
+    vi.resetModules()
+    vi.unstubAllEnvs()
+    // Ensure the env module is unmocked for each test
+    vi.doUnmock('@/lib/env')
+  })
+
+  describe('success cases', () => {
+    it('validates and exports env when all required variables are present', async () => {
+      // Stub all required env vars
+      Object.entries(validEnv).forEach(([key, value]) => {
+        vi.stubEnv(key, value)
+      })
+
+      const { env } = await import('./env')
+
+      expect(env).toEqual(validEnv)
+    })
+
+    it('includes all TMDB environment variables', async () => {
+      Object.entries(validEnv).forEach(([key, value]) => {
+        vi.stubEnv(key, value)
+      })
+
+      const { env } = await import('./env')
+
+      expect(env.TMDB_TV_LIST_ID).toBe('tv-list-123')
+      expect(env.TMDB_MOVIE_LIST_ID).toBe('movie-list-456')
+      expect(env.TMDB_READ_ACCESS_TOKEN).toBe('tmdb-token-xyz')
+    })
+
+    it('includes all Notion environment variables', async () => {
+      Object.entries(validEnv).forEach(([key, value]) => {
+        vi.stubEnv(key, value)
+      })
+
+      const { env } = await import('./env')
+
+      expect(env.NOTION_ACCESS_TOKEN).toBe('notion-token-abc')
+      expect(env.NOTION_DATA_SOURCE_ID_BOOKS).toBe('books-db-id')
+      expect(env.NOTION_DATA_SOURCE_ID_ALBUMS).toBe('albums-db-id')
+      expect(env.NOTION_DATA_SOURCE_ID_PODCASTS).toBe('podcasts-db-id')
+      expect(env.NOTION_DATA_SOURCE_ID_WRITING).toBe('writing-db-id')
+    })
+
+    it('includes all Cloudinary environment variables', async () => {
+      Object.entries(validEnv).forEach(([key, value]) => {
+        vi.stubEnv(key, value)
+      })
+
+      const { env } = await import('./env')
+
+      expect(env.CLOUDINARY_CLOUD_NAME).toBe('my-cloud')
+      expect(env.CLOUDINARY_API_KEY).toBe('cloudinary-key')
+      expect(env.CLOUDINARY_API_SECRET).toBe('cloudinary-secret')
+    })
+  })
+
+  describe('error cases - missing variables', () => {
+    it.each([
+      'TMDB_TV_LIST_ID',
+      'TMDB_MOVIE_LIST_ID',
+      'TMDB_READ_ACCESS_TOKEN',
+      'NOTION_ACCESS_TOKEN',
+      'NOTION_DATA_SOURCE_ID_BOOKS',
+      'NOTION_DATA_SOURCE_ID_ALBUMS',
+      'NOTION_DATA_SOURCE_ID_PODCASTS',
+      'NOTION_DATA_SOURCE_ID_WRITING',
+      'CLOUDINARY_CLOUD_NAME',
+      'CLOUDINARY_API_KEY',
+      'CLOUDINARY_API_SECRET',
+    ])('throws when %s is missing', async key => {
+      // Stub all env vars except the one being tested
+      Object.entries(validEnv).forEach(([envKey, value]) => {
+        if (envKey !== key) {
+          vi.stubEnv(envKey, value)
+        }
+      })
+
+      // When a variable is missing (undefined), Zod says "expected string, received undefined"
+      await expect(import('./env')).rejects.toThrow()
+      await expect(import('./env')).rejects.toThrow(/expected string, received undefined/)
+    })
+  })
+
+  describe('error cases - empty strings', () => {
+    it.each([
+      { key: 'TMDB_TV_LIST_ID', message: 'TMDB_TV_LIST_ID is required' },
+      { key: 'TMDB_MOVIE_LIST_ID', message: 'TMDB_MOVIE_LIST_ID is required' },
+      { key: 'TMDB_READ_ACCESS_TOKEN', message: 'TMDB_READ_ACCESS_TOKEN is required' },
+      { key: 'NOTION_ACCESS_TOKEN', message: 'NOTION_ACCESS_TOKEN is required' },
+      { key: 'NOTION_DATA_SOURCE_ID_BOOKS', message: 'NOTION_DATA_SOURCE_ID_BOOKS is required' },
+      { key: 'NOTION_DATA_SOURCE_ID_ALBUMS', message: 'NOTION_DATA_SOURCE_ID_ALBUMS is required' },
+      { key: 'NOTION_DATA_SOURCE_ID_PODCASTS', message: 'NOTION_DATA_SOURCE_ID_PODCASTS is required' },
+      { key: 'NOTION_DATA_SOURCE_ID_WRITING', message: 'NOTION_DATA_SOURCE_ID_WRITING is required' },
+      { key: 'CLOUDINARY_CLOUD_NAME', message: 'CLOUDINARY_CLOUD_NAME is required' },
+      { key: 'CLOUDINARY_API_KEY', message: 'CLOUDINARY_API_KEY is required' },
+      { key: 'CLOUDINARY_API_SECRET', message: 'CLOUDINARY_API_SECRET is required' },
+    ])('throws when $key is empty string', async ({ key, message }) => {
+      // Stub all env vars, but set the tested one to empty string
+      Object.entries(validEnv).forEach(([envKey, value]) => {
+        vi.stubEnv(envKey, envKey === key ? '' : value)
+      })
+
+      await expect(import('./env')).rejects.toThrow(message)
+    })
+  })
+
+  describe('error cases - validation behavior', () => {
+    it('throws ZodError with helpful message structure', async () => {
+      // Stub all env vars except one
+      Object.entries(validEnv).forEach(([envKey, value]) => {
+        if (envKey !== 'TMDB_TV_LIST_ID') {
+          vi.stubEnv(envKey, value)
+        }
+      })
+
+      try {
+        await import('./env')
+        expect.fail('Should have thrown')
+      } catch (error) {
+        expect(error).toBeInstanceOf(Error)
+        expect((error as Error).message).toContain('TMDB_TV_LIST_ID')
+        expect((error as Error).message).toContain('expected string, received undefined')
+      }
+    })
+
+    it('reports all missing variables at once', async () => {
+      // Stub only half of the required vars
+      vi.stubEnv('TMDB_TV_LIST_ID', 'tv-list')
+      vi.stubEnv('TMDB_MOVIE_LIST_ID', 'movie-list')
+      vi.stubEnv('TMDB_READ_ACCESS_TOKEN', 'token')
+
+      try {
+        await import('./env')
+        expect.fail('Should have thrown')
+      } catch (error) {
+        expect(error).toBeInstanceOf(Error)
+        const message = (error as Error).message
+        // Should report multiple missing vars
+        expect(message).toContain('NOTION_ACCESS_TOKEN')
+        expect(message).toContain('CLOUDINARY_CLOUD_NAME')
+      }
+    })
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,8 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.0",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -32,12 +34,20 @@
         "eslint": "^9",
         "eslint-config-next": "16.0.1",
         "eslint-config-prettier": "^10.1.8",
+        "happy-dom": "^20.0.11",
         "prettier": "^3.6.2",
         "shiki": "^3.15.0",
         "tailwindcss": "^4",
         "typescript": "^5",
         "vitest": "^4.0.15"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -243,6 +253,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -2396,6 +2416,91 @@
         "tailwindcss": "4.1.16"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz",
+      "integrity": "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -2406,6 +2511,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -2507,6 +2619,7 @@
       "integrity": "sha512-9KQPoO6mZCi7jcIStSnlOWn2nEF3mNmyr3rIAsGnAbQKYbRLyqmeSc39EVgtxXVia+LMT8j3knZLAZAh+xLmrw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2521,6 +2634,13 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -3275,6 +3395,16 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -3842,6 +3972,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -4026,6 +4163,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -5172,6 +5316,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/happy-dom": {
+      "version": "20.0.11",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.0.11.tgz",
+      "integrity": "sha512-QsCdAUHAmiDeKeaNojb1OHOPF7NjcWPBR7obdu3NwH2a/oyQaLg5d0aaCy/9My6CdPChYF07dvz5chaXBGaD4g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "^20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "whatwg-mimetype": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -5445,6 +5605,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/internal-slot": {
@@ -6402,6 +6572,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -6944,6 +7124,16 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -7490,6 +7680,41 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -7583,6 +7808,20 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -8357,6 +8596,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -9181,6 +9433,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.0",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
@@ -42,6 +44,7 @@
     "eslint": "^9",
     "eslint-config-next": "16.0.1",
     "eslint-config-prettier": "^10.1.8",
+    "happy-dom": "^20.0.11",
     "prettier": "^3.6.2",
     "shiki": "^3.15.0",
     "tailwindcss": "^4",

--- a/utils/getImagePlaceholderForEnv.test.ts
+++ b/utils/getImagePlaceholderForEnv.test.ts
@@ -64,9 +64,7 @@ describe('getImagePlaceholderForEnv', () => {
       const networkError = new Error('Network request failed')
       global.fetch = vi.fn().mockRejectedValue(networkError)
 
-      await expect(getImagePlaceholderForEnv('https://example.com/image.jpg')).rejects.toThrow(
-        'Network request failed',
-      )
+      await expect(getImagePlaceholderForEnv('https://example.com/image.jpg')).rejects.toThrow('Network request failed')
     })
 
     it('throws when fetch returns 404', async () => {
@@ -145,7 +143,9 @@ describe('getImagePlaceholderForEnv', () => {
       const mockArrayBuffer = vi.fn(async () => imageData.buffer)
       global.fetch = vi.fn(async () => ({ arrayBuffer: mockArrayBuffer }))
 
-      vi.mocked(getPlaiceholder).mockResolvedValue({ base64: 'data:image/png;base64,test' } as any)
+      vi.mocked(getPlaiceholder).mockResolvedValue({
+        base64: 'data:image/png;base64,test',
+      } as Awaited<ReturnType<typeof getPlaiceholder>>)
 
       await getImagePlaceholderForEnv('https://example.com/image.jpg', 8)
 

--- a/utils/getImagePlaceholderForEnv.test.ts
+++ b/utils/getImagePlaceholderForEnv.test.ts
@@ -1,5 +1,8 @@
 import getImagePlaceholderForEnv, { ERRORS } from './getImagePlaceholderForEnv'
 
+const TEST_PLACEHOLDER_SIZE = 16
+const TEST_PLACEHOLDER_SIZE_SMALL = 8
+
 // Mock plaiceholder (vi is globally available)
 vi.mock('plaiceholder', () => ({
   getPlaiceholder: vi.fn(async () => ({
@@ -20,7 +23,7 @@ describe('getImagePlaceholderForEnv', () => {
   it('returns gray pixel placeholder in development', async () => {
     vi.stubEnv('NODE_ENV', 'development')
 
-    const result = await getImagePlaceholderForEnv('https://example.com/image.jpg', 16)
+    const result = await getImagePlaceholderForEnv('https://example.com/image.jpg', TEST_PLACEHOLDER_SIZE)
 
     expect(result).toBe(
       'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mOUkJD+DwAB5wFMR598EAAAAABJRU5ErkJggg==',
@@ -31,10 +34,10 @@ describe('getImagePlaceholderForEnv', () => {
     vi.stubEnv('NODE_ENV', 'production')
 
     const { getPlaiceholder } = await import('plaiceholder')
-    const result = await getImagePlaceholderForEnv('https://example.com/image.jpg', 16)
+    const result = await getImagePlaceholderForEnv('https://example.com/image.jpg', TEST_PLACEHOLDER_SIZE)
 
     // getPlaiceholder should be called with a Buffer (from fetch), not the URL string
-    expect(getPlaiceholder).toHaveBeenCalledWith(expect.any(Buffer), { size: 16 })
+    expect(getPlaiceholder).toHaveBeenCalledWith(expect.any(Buffer), { size: TEST_PLACEHOLDER_SIZE })
     expect(result).toBe('data:image/png;base64,mockedBase64String')
   })
 
@@ -147,10 +150,10 @@ describe('getImagePlaceholderForEnv', () => {
         base64: 'data:image/png;base64,test',
       } as Awaited<ReturnType<typeof getPlaiceholder>>)
 
-      await getImagePlaceholderForEnv('https://example.com/image.jpg', 8)
+      await getImagePlaceholderForEnv('https://example.com/image.jpg', TEST_PLACEHOLDER_SIZE_SMALL)
 
       // Verify Buffer.from was called with the ArrayBuffer
-      expect(getPlaiceholder).toHaveBeenCalledWith(expect.any(Buffer), { size: 8 })
+      expect(getPlaiceholder).toHaveBeenCalledWith(expect.any(Buffer), { size: TEST_PLACEHOLDER_SIZE_SMALL })
 
       // Verify the Buffer contains the image data
       const callArgs = vi.mocked(getPlaiceholder).mock.calls[0]

--- a/utils/getImagePlaceholderForEnv.test.ts
+++ b/utils/getImagePlaceholderForEnv.test.ts
@@ -58,4 +58,125 @@ describe('getImagePlaceholderForEnv', () => {
       '[getImagePlaceholderForEnv]: size argument must be an integer between 4 and 64',
     )
   })
+
+  describe('production error handling', () => {
+    beforeEach(() => {
+      vi.stubEnv('NODE_ENV', 'production')
+    })
+
+    it('throws when fetch fails with network error', async () => {
+      const networkError = new Error('Network request failed')
+      global.fetch = vi.fn().mockRejectedValue(networkError)
+
+      await expect(getImagePlaceholderForEnv('https://example.com/image.jpg')).rejects.toThrow(
+        'Network request failed',
+      )
+    })
+
+    it('throws when fetch returns 404', async () => {
+      global.fetch = vi.fn().mockRejectedValue(new Error('404 Not Found'))
+
+      await expect(getImagePlaceholderForEnv('https://example.com/broken-image.jpg')).rejects.toThrow('404 Not Found')
+    })
+
+    it('throws when fetch returns 500', async () => {
+      global.fetch = vi.fn().mockRejectedValue(new Error('500 Internal Server Error'))
+
+      await expect(getImagePlaceholderForEnv('https://example.com/image.jpg')).rejects.toThrow(
+        '500 Internal Server Error',
+      )
+    })
+
+    it('throws when arrayBuffer() fails', async () => {
+      const arrayBufferError = new Error('Failed to read response body')
+      global.fetch = vi.fn().mockResolvedValue({
+        arrayBuffer: vi.fn().mockRejectedValue(arrayBufferError),
+      })
+
+      await expect(getImagePlaceholderForEnv('https://example.com/image.jpg')).rejects.toThrow(
+        'Failed to read response body',
+      )
+    })
+
+    it('throws when plaiceholder fails with corrupted image', async () => {
+      const { getPlaiceholder } = await import('plaiceholder')
+
+      // Mock successful fetch but plaiceholder failure
+      const mockArrayBuffer = vi.fn(async () => new ArrayBuffer(8))
+      global.fetch = vi.fn(async () => ({ arrayBuffer: mockArrayBuffer }))
+
+      const plaiceholderError = new Error('Input buffer contains unsupported image format')
+      vi.mocked(getPlaiceholder).mockRejectedValue(plaiceholderError)
+
+      await expect(getImagePlaceholderForEnv('https://example.com/corrupt.jpg')).rejects.toThrow(
+        'Input buffer contains unsupported image format',
+      )
+    })
+
+    it('throws when plaiceholder fails with unsupported format', async () => {
+      const { getPlaiceholder } = await import('plaiceholder')
+
+      const mockArrayBuffer = vi.fn(async () => new ArrayBuffer(8))
+      global.fetch = vi.fn(async () => ({ arrayBuffer: mockArrayBuffer }))
+
+      const unsupportedError = new Error('Unsupported image type')
+      vi.mocked(getPlaiceholder).mockRejectedValue(unsupportedError)
+
+      await expect(getImagePlaceholderForEnv('https://example.com/image.tiff')).rejects.toThrow(
+        'Unsupported image type',
+      )
+    })
+
+    it('throws when plaiceholder fails with invalid dimensions', async () => {
+      const { getPlaiceholder } = await import('plaiceholder')
+
+      const mockArrayBuffer = vi.fn(async () => new ArrayBuffer(8))
+      global.fetch = vi.fn(async () => ({ arrayBuffer: mockArrayBuffer }))
+
+      const dimensionError = new Error('Image dimensions are too large')
+      vi.mocked(getPlaiceholder).mockRejectedValue(dimensionError)
+
+      await expect(getImagePlaceholderForEnv('https://example.com/huge-image.jpg')).rejects.toThrow(
+        'Image dimensions are too large',
+      )
+    })
+
+    it('creates Buffer correctly from fetch response', async () => {
+      const { getPlaiceholder } = await import('plaiceholder')
+
+      // Create a realistic ArrayBuffer
+      const imageData = new Uint8Array([0xff, 0xd8, 0xff, 0xe0]) // JPEG header
+      const mockArrayBuffer = vi.fn(async () => imageData.buffer)
+      global.fetch = vi.fn(async () => ({ arrayBuffer: mockArrayBuffer }))
+
+      vi.mocked(getPlaiceholder).mockResolvedValue({ base64: 'data:image/png;base64,test' } as any)
+
+      await getImagePlaceholderForEnv('https://example.com/image.jpg', 8)
+
+      // Verify Buffer.from was called with the ArrayBuffer
+      expect(getPlaiceholder).toHaveBeenCalledWith(expect.any(Buffer), { size: 8 })
+
+      // Verify the Buffer contains the image data
+      const callArgs = vi.mocked(getPlaiceholder).mock.calls[0]
+      const buffer = callArgs[0] as Buffer
+      expect(buffer).toBeInstanceOf(Buffer)
+      expect(buffer.length).toBe(4)
+      expect(buffer[0]).toBe(0xff)
+      expect(buffer[1]).toBe(0xd8)
+    })
+
+    it('handles timeout when fetching remote image', async () => {
+      const timeoutError = new Error('Request timeout')
+      global.fetch = vi.fn().mockRejectedValue(timeoutError)
+
+      await expect(getImagePlaceholderForEnv('https://slow-server.com/image.jpg')).rejects.toThrow('Request timeout')
+    })
+
+    it('throws with helpful error when image URL is invalid', async () => {
+      const invalidUrlError = new Error('Invalid URL')
+      global.fetch = vi.fn().mockRejectedValue(invalidUrlError)
+
+      await expect(getImagePlaceholderForEnv('not-a-valid-url')).rejects.toThrow('Invalid URL')
+    })
+  })
 })

--- a/utils/getImagePlaceholderForEnv.test.ts
+++ b/utils/getImagePlaceholderForEnv.test.ts
@@ -1,4 +1,4 @@
-import getImagePlaceholderForEnv from './getImagePlaceholderForEnv'
+import getImagePlaceholderForEnv, { ERRORS } from './getImagePlaceholderForEnv'
 
 // Mock plaiceholder (vi is globally available)
 vi.mock('plaiceholder', () => ({
@@ -48,15 +48,11 @@ describe('getImagePlaceholderForEnv', () => {
   })
 
   it('throws error if size is less than 4', async () => {
-    await expect(getImagePlaceholderForEnv('https://example.com/image.jpg', 3)).rejects.toThrow(
-      '[getImagePlaceholderForEnv]: size argument must be an integer between 4 and 64',
-    )
+    await expect(getImagePlaceholderForEnv('https://example.com/image.jpg', 3)).rejects.toThrow(ERRORS.INVALID_SIZE)
   })
 
   it('throws error if size is greater than 64', async () => {
-    await expect(getImagePlaceholderForEnv('https://example.com/image.jpg', 65)).rejects.toThrow(
-      '[getImagePlaceholderForEnv]: size argument must be an integer between 4 and 64',
-    )
+    await expect(getImagePlaceholderForEnv('https://example.com/image.jpg', 65)).rejects.toThrow(ERRORS.INVALID_SIZE)
   })
 
   describe('production error handling', () => {

--- a/utils/getImagePlaceholderForEnv.ts
+++ b/utils/getImagePlaceholderForEnv.ts
@@ -1,5 +1,9 @@
 import { getPlaiceholder, type GetPlaiceholderSrc } from 'plaiceholder'
 
+export const ERRORS = {
+  INVALID_SIZE: '[getImagePlaceholderForEnv]: size argument must be an integer between 4 and 64',
+} as const
+
 /**
  * Generates image placeholders with environment-aware behavior.
  * Production: generates actual base64 placeholders from image URLs using plaiceholder.
@@ -11,7 +15,7 @@ import { getPlaiceholder, type GetPlaiceholderSrc } from 'plaiceholder'
 export default async function getImagePlaceholderForEnv(imageUrl: string, size: number = 4): Promise<string> {
   // Validate size argument
   if ((size && size < 4) || (size && size > 64)) {
-    throw Error('[getImagePlaceholderForEnv]: size argument must be an integer between 4 and 64')
+    throw Error(ERRORS.INVALID_SIZE)
   }
 
   if (process.env.NODE_ENV === 'production') {

--- a/utils/getImagePlaceholderForEnv.ts
+++ b/utils/getImagePlaceholderForEnv.ts
@@ -1,4 +1,4 @@
-import { getPlaiceholder, type GetPlaiceholderSrc } from 'plaiceholder'
+import { getPlaiceholder } from 'plaiceholder'
 
 export const ERRORS = {
   INVALID_SIZE: '[getImagePlaceholderForEnv]: size argument must be an integer between 4 and 64',

--- a/utils/zod.test.ts
+++ b/utils/zod.test.ts
@@ -1,0 +1,348 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { z, type ZodError } from 'zod'
+import { formatValidationError, logValidationError } from './zod'
+
+describe('formatValidationError', () => {
+  describe('single field errors', () => {
+    it('formats required field error', () => {
+      const schema = z.object({ title: z.string() })
+      const result = schema.safeParse({})
+
+      if (!result.success) {
+        const formatted = formatValidationError(result.error)
+        expect(formatted).toContain('title')
+        expect(formatted).toContain('expected string')
+      }
+    })
+
+    it('formats type mismatch error', () => {
+      const schema = z.object({ count: z.number() })
+      const result = schema.safeParse({ count: 'not-a-number' })
+
+      if (!result.success) {
+        const formatted = formatValidationError(result.error)
+        expect(formatted).toContain('count')
+        expect(formatted).toContain('expected number')
+      }
+    })
+
+    it('formats string validation error', () => {
+      const schema = z.object({ email: z.string().email() })
+      const result = schema.safeParse({ email: 'not-an-email' })
+
+      if (!result.success) {
+        const formatted = formatValidationError(result.error)
+        expect(formatted).toContain('email')
+        expect(formatted).toContain('Invalid email')
+      }
+    })
+
+    it('formats minimum length error', () => {
+      const schema = z.object({ name: z.string().min(3) })
+      const result = schema.safeParse({ name: 'ab' })
+
+      if (!result.success) {
+        const formatted = formatValidationError(result.error)
+        expect(formatted).toContain('name')
+        expect(formatted).toContain('>=3 characters')
+      }
+    })
+
+    it('formats regex pattern error', () => {
+      const schema = z.object({ date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/) })
+      const result = schema.safeParse({ date: 'invalid-date' })
+
+      if (!result.success) {
+        const formatted = formatValidationError(result.error)
+        expect(formatted).toContain('date')
+        expect(formatted).toContain('Invalid')
+      }
+    })
+  })
+
+  describe('nested field errors', () => {
+    it('formats nested object field errors with dot notation', () => {
+      const schema = z.object({
+        user: z.object({
+          profile: z.object({
+            name: z.string(),
+          }),
+        }),
+      })
+      const result = schema.safeParse({ user: { profile: {} } })
+
+      if (!result.success) {
+        const formatted = formatValidationError(result.error)
+        expect(formatted).toContain('user.profile.name')
+        expect(formatted).toContain('expected string')
+      }
+    })
+
+    it('formats array index errors with numeric path', () => {
+      const schema = z.object({
+        items: z.array(
+          z.object({
+            id: z.number(),
+          }),
+        ),
+      })
+      const result = schema.safeParse({ items: [{ id: 1 }, { id: 'invalid' }, { id: 3 }] })
+
+      if (!result.success) {
+        const formatted = formatValidationError(result.error)
+        expect(formatted).toContain('items.1.id')
+        expect(formatted).toContain('expected number')
+      }
+    })
+
+    it('formats deeply nested errors', () => {
+      const schema = z.object({
+        data: z.object({
+          metadata: z.object({
+            properties: z.object({
+              title: z.object({
+                value: z.string(),
+              }),
+            }),
+          }),
+        }),
+      })
+      const result = schema.safeParse({ data: { metadata: { properties: { title: {} } } } })
+
+      if (!result.success) {
+        const formatted = formatValidationError(result.error)
+        expect(formatted).toContain('data.metadata.properties.title.value')
+        expect(formatted).toContain('expected string')
+      }
+    })
+  })
+
+  describe('multiple field errors', () => {
+    it('formats multiple errors with comma separation', () => {
+      const schema = z.object({
+        title: z.string().min(1),
+        count: z.number(),
+        email: z.string().email(),
+      })
+      const result = schema.safeParse({})
+
+      if (!result.success) {
+        const formatted = formatValidationError(result.error)
+        expect(formatted).toContain('title')
+        expect(formatted).toContain('count')
+        expect(formatted).toContain('email')
+        // Verify errors are comma-separated (messages contain commas too, so just check presence)
+        expect(formatted).toMatch(/title:.*,.*count:.*,.*email:/)
+      }
+    })
+
+    it('maintains order of errors', () => {
+      const schema = z.object({
+        first: z.string(),
+        second: z.string(),
+        third: z.string(),
+      })
+      const result = schema.safeParse({})
+
+      if (!result.success) {
+        const formatted = formatValidationError(result.error)
+        const firstIndex = formatted.indexOf('first')
+        const secondIndex = formatted.indexOf('second')
+        const thirdIndex = formatted.indexOf('third')
+
+        expect(firstIndex).toBeLessThan(secondIndex)
+        expect(secondIndex).toBeLessThan(thirdIndex)
+      }
+    })
+
+    it('formats complex multi-field validation errors', () => {
+      const schema = z.object({
+        slug: z.string().regex(/^[a-z0-9-]+$/),
+        title: z.string().min(1),
+        date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+        count: z.number().positive(),
+      })
+      const result = schema.safeParse({
+        slug: 'Invalid Slug!',
+        title: '',
+        date: 'invalid-date',
+        count: -5,
+      })
+
+      if (!result.success) {
+        const formatted = formatValidationError(result.error)
+        expect(formatted).toContain('slug')
+        expect(formatted).toContain('title')
+        expect(formatted).toContain('date')
+        expect(formatted).toContain('count')
+      }
+    })
+  })
+
+  describe('empty path errors', () => {
+    it('formats errors with empty path', () => {
+      const schema = z.string()
+      const result = schema.safeParse(123)
+
+      if (!result.success) {
+        const formatted = formatValidationError(result.error)
+        expect(formatted).toContain('expected string')
+      }
+    })
+  })
+
+  describe('real-world scenarios', () => {
+    it('formats Notion post validation error', () => {
+      const PostSchema = z.object({
+        slug: z.string().min(1),
+        title: z.string().min(1),
+        firstPublished: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+      })
+
+      const result = PostSchema.safeParse({
+        slug: '',
+        title: 'Valid Title',
+        firstPublished: 'invalid-date',
+      })
+
+      if (!result.success) {
+        const formatted = formatValidationError(result.error)
+        expect(formatted).toContain('slug')
+        expect(formatted).toContain('firstPublished')
+        expect(formatted).not.toContain('title') // title is valid
+      }
+    })
+
+    it('formats media item validation error', () => {
+      const MediaSchema = z.object({
+        appleId: z.number().positive(),
+        name: z.string().min(1),
+        date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+      })
+
+      const result = MediaSchema.safeParse({
+        appleId: -1,
+        name: '',
+        date: '2024-01-01',
+      })
+
+      if (!result.success) {
+        const formatted = formatValidationError(result.error)
+        expect(formatted).toContain('appleId')
+        expect(formatted).toContain('name')
+        expect(formatted).not.toContain('date') // date is valid
+      }
+    })
+  })
+})
+
+describe('logValidationError', () => {
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore()
+  })
+
+  it('logs validation error with context', () => {
+    const schema = z.object({ title: z.string() })
+    const result = schema.safeParse({})
+
+    if (!result.success) {
+      logValidationError(result.error, 'post')
+      expect(consoleWarnSpy).toHaveBeenCalledOnce()
+      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('Skipping invalid post'))
+      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('title'))
+    }
+  })
+
+  it('includes formatted error details in log message', () => {
+    const schema = z.object({
+      slug: z.string(),
+      count: z.number(),
+    })
+    const result = schema.safeParse({})
+
+    if (!result.success) {
+      logValidationError(result.error, 'item')
+      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('slug'))
+      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('count'))
+    }
+  })
+
+  it('uses correct log format: "Skipping invalid {context} ({errors})"', () => {
+    const schema = z.object({ name: z.string() })
+    const result = schema.safeParse({})
+
+    if (!result.success) {
+      logValidationError(result.error, 'book')
+      const logMessage = consoleWarnSpy.mock.calls[0][0]
+      expect(logMessage).toMatch(/^Skipping invalid book \(.+\)$/)
+    }
+  })
+
+  it('handles different context strings appropriately', () => {
+    const schema = z.object({ value: z.string() })
+    const result = schema.safeParse({})
+
+    if (!result.success) {
+      const contexts = ['post', 'block', 'media item', 'TMDB result', 'iTunes result']
+
+      contexts.forEach(context => {
+        consoleWarnSpy.mockClear()
+        logValidationError(result.error, context)
+        expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining(`Skipping invalid ${context}`))
+      })
+    }
+  })
+
+  it('logs helpful message for build-time debugging', () => {
+    const schema = z.object({
+      slug: z.string().regex(/^[a-z0-9-]+$/),
+      date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+    })
+    const result = schema.safeParse({
+      slug: 'Invalid Slug!',
+      date: 'bad-date',
+    })
+
+    if (!result.success) {
+      logValidationError(result.error, 'post')
+      const logMessage = consoleWarnSpy.mock.calls[0][0]
+
+      // Verify message contains enough detail to debug
+      expect(logMessage).toContain('post')
+      expect(logMessage).toContain('slug')
+      expect(logMessage).toContain('date')
+
+      // Verify message is concise (not too verbose)
+      expect(logMessage.length).toBeLessThan(200)
+    }
+  })
+
+  it('uses console.warn for visibility during builds', () => {
+    const schema = z.object({ test: z.string() })
+    const result = schema.safeParse({})
+
+    if (!result.success) {
+      logValidationError(result.error, 'test')
+
+      // Verify it's using console.warn (not console.log or console.error)
+      expect(consoleWarnSpy).toHaveBeenCalled()
+    }
+  })
+
+  it('does not throw - allows build to continue with warning', () => {
+    const schema = z.object({ value: z.string() })
+    const result = schema.safeParse({})
+
+    if (!result.success) {
+      expect(() => {
+        logValidationError(result.error, 'item')
+      }).not.toThrow()
+    }
+  })
+})

--- a/utils/zod.test.ts
+++ b/utils/zod.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
-import { z, type ZodError } from 'zod'
+import { z } from 'zod'
 import { formatValidationError, logValidationError } from './zod'
 
 describe('formatValidationError', () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,9 @@ import path from 'path'
 export default defineConfig({
   test: {
     globals: true,
-    environment: 'happy-dom',
+    // Default to node environment for most tests (lib/, utils/, etc.)
+    // Component tests specify happy-dom via @vitest-environment docblock
+    environment: 'node',
     setupFiles: ['./vitest.setup.ts'],
   },
   resolve: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,7 @@ import path from 'path'
 export default defineConfig({
   test: {
     globals: true,
+    environment: 'happy-dom',
     setupFiles: ['./vitest.setup.ts'],
   },
   resolve: {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,4 +1,5 @@
 import { vi } from 'vitest'
+import '@testing-library/jest-dom/vitest'
 
 // Make vi globally available
 ;(global as unknown as { vi: typeof vi }).vi = vi


### PR DESCRIPTION
## ✅ What

- Adds 85 new tests for build-time logic (218 → 303 total tests)
- Tests `generateStaticParams` that determines which blog pages to pre-render
- Tests Server Component page logic (blog index, dynamic routes, likes page)
- Tests environment variable validation (all 11 required vars)
- Tests Zod error formatting and logging utilities
- Tests image placeholder generation error scenarios (network failures, corrupt images, timeouts)
- Extracts error messages into constants for easier maintenance
- Documents all testing gaps in `.claude/specs/build-time-testing-gaps-analysis.md`

## 🤔 Why

- Build failures are expensive - they block deployments and require manual investigation
- Unit tests catch issues before builds run, providing fast feedback during development
- Error messages as constants mean polishing error text won't break tests
- Analysis document provides roadmap for future testing improvements (build integration tests planned next)

## 🔖 Related

- Next step: Implement [build integration tests plan](./.claude/specs/build-integration-tests-plan.md) in a follow-up PR