### PR TITLE
Remove about page and polish home bio

### DIFF
--- a/app/(prose)/about/page.tsx
+++ b/app/(prose)/about/page.tsx
@@ -1,5 +1,0 @@
-import { type ReactElement } from 'react'
-
-export default function About(): ReactElement {
-  return <main className="flex-auto">about</main>
-}

--- a/app/(prose)/page.tsx
+++ b/app/(prose)/page.tsx
@@ -6,7 +6,7 @@ import PostList from '@/ui/post-list'
 
 function Summary(): ReactElement {
   return (
-    <section className="md:flex md:justify-between md:items-end md:gap-x-8">
+    <section className="md:flex md:justify-between md:items-end md:gap-x-9">
       <div>
         <h1 className="leading-tight text-[2.5rem] font-bold text-bright">Hey, I&apos;m Michael</h1>
         <Paragraph className="text-lg text-zinc-300">
@@ -14,8 +14,8 @@ function Summary(): ReactElement {
         </Paragraph>
         <Paragraph className="text-zinc-300">
           I&apos;ve built dozens of polished UIs. And a resilient shopping cart. And highly validated data pipelines. I
-          care about reliability, ergonomics and getting the details right. I&apos;d rather not get paged, so I spend
-          time thinking about what could go wrong and how to make sure it doesn&apos;t.
+          care about reliability, ergonomics and getting the details right. And since I&apos;d rather not get paged, I
+          often think about what else could go wrong and how to make sure it doesn&apos;t.
         </Paragraph>
       </div>
 

--- a/ui/nav/primary.tsx
+++ b/ui/nav/primary.tsx
@@ -14,7 +14,7 @@ const nav: NavItem[] = [
   { text: 'Blog', href: '/blog/' },
   // { text: 'Videos', href: '/videos/' },
   // { text: 'Projects', href: '/projects/' },
-  { text: 'About', href: '/about/' },
+  // { text: 'About', href: '/about/' },
   { text: 'Likes', href: '/likes/' },
 ]
 

--- a/ui/nav/utils.test.ts
+++ b/ui/nav/utils.test.ts
@@ -29,11 +29,6 @@ describe('isCurrentPage', () => {
       expect(isCurrentPage(navItem, '/', mockPosts)).toBe(true)
     })
 
-    it('returns true when navItem href matches pathname for /about/', () => {
-      const navItem: NavItem = { text: 'About', href: '/about/' }
-      expect(isCurrentPage(navItem, '/about/', mockPosts)).toBe(true)
-    })
-
     it('returns true when navItem href matches pathname for /likes/', () => {
       const navItem: NavItem = { text: 'Likes', href: '/likes/' }
       expect(isCurrentPage(navItem, '/likes/', mockPosts)).toBe(true)
@@ -41,7 +36,7 @@ describe('isCurrentPage', () => {
 
     it('returns false when navItem href does not match pathname', () => {
       const navItem: NavItem = { text: 'Home', href: '/' }
-      expect(isCurrentPage(navItem, '/about/', mockPosts)).toBe(false)
+      expect(isCurrentPage(navItem, '/blog/', mockPosts)).toBe(false)
     })
   })
 


### PR DESCRIPTION
## What

- Removes placeholder about page
- Comments out "About" link from navigation
- Polishes home page bio phrasing for better flow
- Adjusts bio/photo spacing (gap-x-8 → gap-x-9)

## Why

- The about page was just placeholder text with no content
- The home page bio already introduces me, so a separate about page is redundant
- Bio phrasing improvements make the text flow more naturally

## How to validate

1. `npm run dev` and visit `http://localhost:3000`
2. Expect to see improved bio text: "And since I'd rather not get paged, I often think about what else could go wrong..."
3. Check the nav bar
4. Expect the "About" link to no longer appear
5. Try visiting `/about/` directly
6. Expect to see a 404 page