### PR TITLE
Add sitemap and robots.txt for SEO

### DIFF
--- a/app/layout.test.tsx
+++ b/app/layout.test.tsx
@@ -8,9 +8,7 @@ import { metadata } from './layout'
 describe('RootLayout metadata', () => {
   it('includes basic site information', () => {
     expect(metadata.title).toBe('Michael Uloth')
-    expect(metadata.description).toBe(
-      'Software engineer helping scientists discover new medicines at Recursion.',
-    )
+    expect(metadata.description).toBe('Software engineer helping scientists discover new medicines at Recursion.')
   })
 
   it('includes RSS feed link', () => {

--- a/app/layout.test.tsx
+++ b/app/layout.test.tsx
@@ -18,14 +18,4 @@ describe('RootLayout metadata', () => {
       'application/rss+xml': '/rss.xml',
     })
   })
-
-  it('includes sitemap link in head', () => {
-    expect(metadata.icons?.other).toEqual([
-      {
-        rel: 'sitemap',
-        type: 'application/xml',
-        url: '/sitemap.xml',
-      },
-    ])
-  })
 })

--- a/app/layout.test.tsx
+++ b/app/layout.test.tsx
@@ -1,0 +1,31 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { describe, expect, it } from 'vitest'
+import { metadata } from './layout'
+
+describe('RootLayout metadata', () => {
+  it('includes basic site information', () => {
+    expect(metadata.title).toBe('Michael Uloth')
+    expect(metadata.description).toBe(
+      'Software engineer helping scientists discover new medicines at Recursion.',
+    )
+  })
+
+  it('includes RSS feed link', () => {
+    expect(metadata.alternates?.types).toEqual({
+      'application/rss+xml': '/rss.xml',
+    })
+  })
+
+  it('includes sitemap link in head', () => {
+    expect(metadata.icons?.other).toEqual([
+      {
+        rel: 'sitemap',
+        type: 'application/xml',
+        url: '/sitemap.xml',
+      },
+    ])
+  })
+})

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,15 +15,6 @@ export const metadata: Metadata = {
       'application/rss+xml': '/rss.xml',
     },
   },
-  icons: {
-    other: [
-      {
-        rel: 'sitemap',
-        type: 'application/xml',
-        url: '/sitemap.xml',
-      },
-    ],
-  },
 }
 
 type Props = Readonly<{

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,6 +15,15 @@ export const metadata: Metadata = {
       'application/rss+xml': '/rss.xml',
     },
   },
+  icons: {
+    other: [
+      {
+        rel: 'sitemap',
+        type: 'application/xml',
+        url: '/sitemap.xml',
+      },
+    ],
+  },
 }
 
 type Props = Readonly<{

--- a/app/robots.test.ts
+++ b/app/robots.test.ts
@@ -1,0 +1,35 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { describe, expect, it } from 'vitest'
+import robots from './robots'
+
+describe('robots', () => {
+  it('allows all user agents to crawl all pages', () => {
+    const config = robots()
+
+    expect(config.rules).toEqual({
+      userAgent: '*',
+      allow: '/',
+    })
+  })
+
+  it('references the sitemap location', () => {
+    const config = robots()
+
+    expect(config.sitemap).toBe('https://michaeluloth.com/sitemap.xml')
+  })
+
+  it('returns complete robots configuration', () => {
+    const config = robots()
+
+    expect(config).toEqual({
+      rules: {
+        userAgent: '*',
+        allow: '/',
+      },
+      sitemap: 'https://michaeluloth.com/sitemap.xml',
+    })
+  })
+})

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,6 +1,5 @@
 import type { MetadataRoute } from 'next'
-
-const SITE_URL = 'https://michaeluloth.com/'
+import { SITE_URL } from '@/utils/constants'
 
 export const dynamic = 'force-static'
 

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from 'next'
+
+const SITE_URL = 'https://michaeluloth.com/'
+
+export const dynamic = 'force-static'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+    },
+    sitemap: `${SITE_URL}sitemap.xml`,
+  }
+}

--- a/app/rss.xml/route.test.ts
+++ b/app/rss.xml/route.test.ts
@@ -269,7 +269,7 @@ describe('RSS feed route', () => {
       expect(getBlockChildren).toHaveBeenCalledWith('post-1')
     })
 
-    it('skips posts that fail to fetch blocks', async () => {
+    it('throws when block fetch fails', async () => {
       const mockPostListItems: PostListItem[] = [
         {
           id: 'post-1',
@@ -313,12 +313,8 @@ describe('RSS feed route', () => {
         .mockResolvedValueOnce(Ok(mockBlocks))
         .mockResolvedValueOnce(Err(new Error('Block fetch failed')))
 
-      const response = await GET()
-      const xml = await response.text()
-
-      // Verify only valid post is included
-      expect(xml).toContain('<![CDATA[Valid Post]]>')
-      expect(xml).not.toContain('<![CDATA[Broken Post]]>')
+      // Should throw when block fetch fails, preventing incomplete RSS feed
+      await expect(GET()).rejects.toThrow('Block fetch failed')
     })
 
     it('handles posts without description', async () => {

--- a/app/rss.xml/route.ts
+++ b/app/rss.xml/route.ts
@@ -2,8 +2,7 @@ import { Feed } from 'feed'
 import getPosts from '@/io/notion/getPosts'
 import getBlockChildren from '@/io/notion/getBlockChildren'
 import { renderBlocksToHtml } from '@/io/notion/renderBlocksToHtml'
-
-const SITE_URL = 'https://michaeluloth.com/'
+import { SITE_URL } from '@/utils/constants'
 
 export const dynamic = 'force-static'
 

--- a/app/rss.xml/route.ts
+++ b/app/rss.xml/route.ts
@@ -25,16 +25,11 @@ export async function GET() {
   // Fetch blocks for each post (we already have metadata from getPosts)
   for (const postItem of posts) {
     console.log(`[RSS] Fetching blocks for: ${postItem.slug}`)
-    const blocksResult = await getBlockChildren(postItem.id)
-
-    if (!blocksResult.ok) {
-      console.error(`[RSS] Failed to fetch blocks for ${postItem.slug}:`, blocksResult.error)
-      continue
-    }
+    const blocks = (await getBlockChildren(postItem.id)).unwrap()
 
     const content = postItem.featuredImage
-      ? `<img src="${postItem.featuredImage}" alt="${postItem.title}" />\n${renderBlocksToHtml(blocksResult.value)}`
-      : renderBlocksToHtml(blocksResult.value)
+      ? `<img src="${postItem.featuredImage}" alt="${postItem.title}" />\n${renderBlocksToHtml(blocks)}`
+      : renderBlocksToHtml(blocks)
 
     // Use feedId if present (for historical feed stability), otherwise construct permalink
     const permalink = postItem.feedId || `${SITE_URL}${postItem.slug}/`

--- a/app/sitemap.test.ts
+++ b/app/sitemap.test.ts
@@ -1,0 +1,130 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import sitemap from './sitemap'
+import getPosts from '@/io/notion/getPosts'
+import type { PostListItem } from '@/io/notion/schemas/post'
+import { Ok } from '@/utils/errors/result'
+
+// Mock dependencies
+vi.mock('@/io/notion/getPosts')
+
+describe('sitemap', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('includes static pages with correct priorities', async () => {
+    vi.mocked(getPosts).mockResolvedValue(Ok([]))
+
+    const urls = await sitemap()
+
+    const homePage = urls.find((u) => u.url === 'https://michaeluloth.com')
+    expect(homePage).toBeDefined()
+    expect(homePage?.priority).toBe(1)
+
+    const blogPage = urls.find((u) => u.url === 'https://michaeluloth.com/blog')
+    expect(blogPage).toBeDefined()
+    expect(blogPage?.priority).toBe(0.8)
+    expect(blogPage?.changeFrequency).toBe('weekly')
+
+    const likesPage = urls.find((u) => u.url === 'https://michaeluloth.com/likes')
+    expect(likesPage).toBeDefined()
+    expect(likesPage?.priority).toBe(0.5)
+  })
+
+  it('includes blog posts with lastModified dates', async () => {
+    const mockPosts: PostListItem[] = [
+      {
+        id: 'post-1',
+        slug: 'test-post',
+        title: 'Test Post',
+        description: null,
+        firstPublished: '2024-01-15',
+        featuredImage: null,
+        feedId: null,
+      },
+      {
+        id: 'post-2',
+        slug: 'another-post',
+        title: 'Another Post',
+        description: null,
+        firstPublished: '2024-02-20',
+        featuredImage: null,
+        feedId: null,
+      },
+    ]
+
+    vi.mocked(getPosts).mockResolvedValue(Ok(mockPosts))
+
+    const urls = await sitemap()
+
+    const post1 = urls.find((u) => u.url === 'https://michaeluloth.com/test-post')
+    expect(post1).toBeDefined()
+    expect(post1?.lastModified).toEqual(new Date('2024-01-15'))
+    expect(post1?.priority).toBe(0.7)
+
+    const post2 = urls.find((u) => u.url === 'https://michaeluloth.com/another-post')
+    expect(post2).toBeDefined()
+    expect(post2?.lastModified).toEqual(new Date('2024-02-20'))
+    expect(post2?.priority).toBe(0.7)
+  })
+
+  it('fetches posts with descending sort order', async () => {
+    vi.mocked(getPosts).mockResolvedValue(Ok([]))
+
+    await sitemap()
+
+    expect(getPosts).toHaveBeenCalledWith({ sortDirection: 'descending' })
+  })
+
+  it('returns all URLs (static pages + blog posts)', async () => {
+    const mockPosts: PostListItem[] = [
+      {
+        id: 'post-1',
+        slug: 'first-post',
+        title: 'First Post',
+        description: null,
+        firstPublished: '2024-01-15',
+        featuredImage: null,
+        feedId: null,
+      },
+      {
+        id: 'post-2',
+        slug: 'second-post',
+        title: 'Second Post',
+        description: null,
+        firstPublished: '2024-02-20',
+        featuredImage: null,
+        feedId: null,
+      },
+    ]
+
+    vi.mocked(getPosts).mockResolvedValue(Ok(mockPosts))
+
+    const urls = await sitemap()
+
+    // 3 static pages + 2 blog posts = 5 total
+    expect(urls).toHaveLength(5)
+
+    // Verify all URLs are present
+    const urlStrings = urls.map((u) => u.url)
+    expect(urlStrings).toContain('https://michaeluloth.com')
+    expect(urlStrings).toContain('https://michaeluloth.com/blog')
+    expect(urlStrings).toContain('https://michaeluloth.com/likes')
+    expect(urlStrings).toContain('https://michaeluloth.com/first-post')
+    expect(urlStrings).toContain('https://michaeluloth.com/second-post')
+  })
+
+  it('handles empty blog posts list', async () => {
+    vi.mocked(getPosts).mockResolvedValue(Ok([]))
+
+    const urls = await sitemap()
+
+    // Only 3 static pages
+    expect(urls).toHaveLength(3)
+    expect(urls.every((u) => u.url.startsWith('https://michaeluloth.com'))).toBe(true)
+  })
+})

--- a/app/sitemap.test.ts
+++ b/app/sitemap.test.ts
@@ -21,7 +21,7 @@ describe('sitemap', () => {
 
     const urls = await sitemap()
 
-    const homePage = urls.find((u) => u.url === 'https://michaeluloth.com')
+    const homePage = urls.find((u) => u.url === 'https://michaeluloth.com/')
     expect(homePage).toBeDefined()
     expect(homePage?.priority).toBe(1)
 
@@ -61,12 +61,12 @@ describe('sitemap', () => {
 
     const urls = await sitemap()
 
-    const post1 = urls.find((u) => u.url === 'https://michaeluloth.com/test-post')
+    const post1 = urls.find((u) => u.url === 'https://michaeluloth.com/test-post/')
     expect(post1).toBeDefined()
     expect(post1?.lastModified).toEqual(new Date('2024-01-15'))
     expect(post1?.priority).toBe(0.7)
 
-    const post2 = urls.find((u) => u.url === 'https://michaeluloth.com/another-post')
+    const post2 = urls.find((u) => u.url === 'https://michaeluloth.com/another-post/')
     expect(post2).toBeDefined()
     expect(post2?.lastModified).toEqual(new Date('2024-02-20'))
     expect(post2?.priority).toBe(0.7)
@@ -111,11 +111,11 @@ describe('sitemap', () => {
 
     // Verify all URLs are present
     const urlStrings = urls.map((u) => u.url)
-    expect(urlStrings).toContain('https://michaeluloth.com')
+    expect(urlStrings).toContain('https://michaeluloth.com/')
     expect(urlStrings).toContain('https://michaeluloth.com/blog')
     expect(urlStrings).toContain('https://michaeluloth.com/likes')
-    expect(urlStrings).toContain('https://michaeluloth.com/first-post')
-    expect(urlStrings).toContain('https://michaeluloth.com/second-post')
+    expect(urlStrings).toContain('https://michaeluloth.com/first-post/')
+    expect(urlStrings).toContain('https://michaeluloth.com/second-post/')
   })
 
   it('handles empty blog posts list', async () => {
@@ -125,6 +125,6 @@ describe('sitemap', () => {
 
     // Only 3 static pages
     expect(urls).toHaveLength(3)
-    expect(urls.every((u) => u.url.startsWith('https://michaeluloth.com'))).toBe(true)
+    expect(urls.every((u) => u.url.startsWith('https://michaeluloth.com/'))).toBe(true)
   })
 })

--- a/app/sitemap.test.ts
+++ b/app/sitemap.test.ts
@@ -21,16 +21,16 @@ describe('sitemap', () => {
 
     const urls = await sitemap()
 
-    const homePage = urls.find((u) => u.url === 'https://michaeluloth.com/')
+    const homePage = urls.find(u => u.url === 'https://michaeluloth.com/')
     expect(homePage).toBeDefined()
     expect(homePage?.priority).toBe(1)
 
-    const blogPage = urls.find((u) => u.url === 'https://michaeluloth.com/blog/')
+    const blogPage = urls.find(u => u.url === 'https://michaeluloth.com/blog/')
     expect(blogPage).toBeDefined()
     expect(blogPage?.priority).toBe(0.8)
     expect(blogPage?.changeFrequency).toBe('weekly')
 
-    const likesPage = urls.find((u) => u.url === 'https://michaeluloth.com/likes/')
+    const likesPage = urls.find(u => u.url === 'https://michaeluloth.com/likes/')
     expect(likesPage).toBeDefined()
     expect(likesPage?.priority).toBe(0.5)
   })
@@ -61,12 +61,12 @@ describe('sitemap', () => {
 
     const urls = await sitemap()
 
-    const post1 = urls.find((u) => u.url === 'https://michaeluloth.com/test-post/')
+    const post1 = urls.find(u => u.url === 'https://michaeluloth.com/test-post/')
     expect(post1).toBeDefined()
     expect(post1?.lastModified).toEqual(new Date('2024-01-15'))
     expect(post1?.priority).toBe(0.7)
 
-    const post2 = urls.find((u) => u.url === 'https://michaeluloth.com/another-post/')
+    const post2 = urls.find(u => u.url === 'https://michaeluloth.com/another-post/')
     expect(post2).toBeDefined()
     expect(post2?.lastModified).toEqual(new Date('2024-02-20'))
     expect(post2?.priority).toBe(0.7)
@@ -110,7 +110,7 @@ describe('sitemap', () => {
     expect(urls).toHaveLength(5)
 
     // Verify all URLs are present
-    const urlStrings = urls.map((u) => u.url)
+    const urlStrings = urls.map(u => u.url)
     expect(urlStrings).toContain('https://michaeluloth.com/')
     expect(urlStrings).toContain('https://michaeluloth.com/blog/')
     expect(urlStrings).toContain('https://michaeluloth.com/likes/')
@@ -125,6 +125,6 @@ describe('sitemap', () => {
 
     // Only 3 static pages
     expect(urls).toHaveLength(3)
-    expect(urls.every((u) => u.url.startsWith('https://michaeluloth.com/'))).toBe(true)
+    expect(urls.every(u => u.url.startsWith('https://michaeluloth.com/'))).toBe(true)
   })
 })

--- a/app/sitemap.test.ts
+++ b/app/sitemap.test.ts
@@ -25,12 +25,12 @@ describe('sitemap', () => {
     expect(homePage).toBeDefined()
     expect(homePage?.priority).toBe(1)
 
-    const blogPage = urls.find((u) => u.url === 'https://michaeluloth.com/blog')
+    const blogPage = urls.find((u) => u.url === 'https://michaeluloth.com/blog/')
     expect(blogPage).toBeDefined()
     expect(blogPage?.priority).toBe(0.8)
     expect(blogPage?.changeFrequency).toBe('weekly')
 
-    const likesPage = urls.find((u) => u.url === 'https://michaeluloth.com/likes')
+    const likesPage = urls.find((u) => u.url === 'https://michaeluloth.com/likes/')
     expect(likesPage).toBeDefined()
     expect(likesPage?.priority).toBe(0.5)
   })
@@ -112,8 +112,8 @@ describe('sitemap', () => {
     // Verify all URLs are present
     const urlStrings = urls.map((u) => u.url)
     expect(urlStrings).toContain('https://michaeluloth.com/')
-    expect(urlStrings).toContain('https://michaeluloth.com/blog')
-    expect(urlStrings).toContain('https://michaeluloth.com/likes')
+    expect(urlStrings).toContain('https://michaeluloth.com/blog/')
+    expect(urlStrings).toContain('https://michaeluloth.com/likes/')
     expect(urlStrings).toContain('https://michaeluloth.com/first-post/')
     expect(urlStrings).toContain('https://michaeluloth.com/second-post/')
   })

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,7 +1,7 @@
 import type { MetadataRoute } from 'next'
 import getPosts from '@/io/notion/getPosts'
 
-const SITE_URL = 'https://michaeluloth.com'
+const SITE_URL = 'https://michaeluloth.com/'
 
 export const dynamic = 'force-static'
 
@@ -10,12 +10,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   const staticPages: MetadataRoute.Sitemap = [
     { url: SITE_URL, priority: 1 },
-    { url: `${SITE_URL}/blog`, changeFrequency: 'weekly', priority: 0.8 },
-    { url: `${SITE_URL}/likes`, priority: 0.5 },
+    { url: `${SITE_URL}blog`, changeFrequency: 'weekly', priority: 0.8 },
+    { url: `${SITE_URL}likes`, priority: 0.5 },
   ]
 
   const blogPosts: MetadataRoute.Sitemap = posts.map((post) => ({
-    url: `${SITE_URL}/${post.slug}`,
+    url: `${SITE_URL}${post.slug}/`,
     lastModified: new Date(post.firstPublished),
     priority: 0.7,
   }))

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -10,11 +10,11 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   const staticPages: MetadataRoute.Sitemap = [
     { url: SITE_URL, priority: 1 },
-    { url: `${SITE_URL}blog`, changeFrequency: 'weekly', priority: 0.8 },
-    { url: `${SITE_URL}likes`, priority: 0.5 },
+    { url: `${SITE_URL}blog/`, changeFrequency: 'weekly', priority: 0.8 },
+    { url: `${SITE_URL}likes/`, priority: 0.5 },
   ]
 
-  const blogPosts: MetadataRoute.Sitemap = posts.map((post) => ({
+  const blogPosts: MetadataRoute.Sitemap = posts.map(post => ({
     url: `${SITE_URL}${post.slug}/`,
     lastModified: new Date(post.firstPublished),
     priority: 0.7,

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,24 @@
+import type { MetadataRoute } from 'next'
+import getPosts from '@/io/notion/getPosts'
+
+const SITE_URL = 'https://michaeluloth.com'
+
+export const dynamic = 'force-static'
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const posts = (await getPosts({ sortDirection: 'descending' })).unwrap()
+
+  const staticPages: MetadataRoute.Sitemap = [
+    { url: SITE_URL, priority: 1 },
+    { url: `${SITE_URL}/blog`, changeFrequency: 'weekly', priority: 0.8 },
+    { url: `${SITE_URL}/likes`, priority: 0.5 },
+  ]
+
+  const blogPosts: MetadataRoute.Sitemap = posts.map((post) => ({
+    url: `${SITE_URL}/${post.slug}`,
+    lastModified: new Date(post.firstPublished),
+    priority: 0.7,
+  }))
+
+  return [...staticPages, ...blogPosts]
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,7 +1,6 @@
 import type { MetadataRoute } from 'next'
 import getPosts from '@/io/notion/getPosts'
-
-const SITE_URL = 'https://michaeluloth.com/'
+import { SITE_URL } from '@/utils/constants'
 
 export const dynamic = 'force-static'
 

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -1,0 +1,6 @@
+/**
+ * Site URL with trailing slash.
+ * IMPORTANT: The trailing slash ensures consistent URL formatting across
+ * sitemap, robots.txt, and RSS feed. All page URLs use trailing slashes.
+ */
+export const SITE_URL = 'https://michaeluloth.com/'


### PR DESCRIPTION
## ✅ What

- Adds `/sitemap.xml` with all static pages and dynamic blog posts from Notion
- Adds `/robots.txt` that allows all crawlers and references the sitemap
- Adds sitemap link to HTML `<head>` for search engine discovery
- Uses trailing slashes in URLs to match existing RSS feed format
- All files statically generated at build time

## 🤔 Why

- Search engines can now efficiently discover and index all site content
- Better SEO means more organic traffic to blog posts
- Sitemap auto-updates when new blog posts are published in Notion