### PR TITLE
Assert unrecognized Cloudinary URL variant throws in transformCloudinaryImage

### DIFF
--- a/io/cloudinary/transformCloudinaryImage.test.ts
+++ b/io/cloudinary/transformCloudinaryImage.test.ts
@@ -25,9 +25,10 @@ describe('transformCloudinaryImage', () => {
     expect(result).toBe(input)
   })
 
-  it('returns URL unchanged if Cloudinary URL but no known transformation type', () => {
+  it('throws for a Cloudinary URL with no known transformation type', () => {
     const input = 'https://res.cloudinary.com/demo/image.jpg'
-    const result = transformCloudinaryImage(input, 400)
-    expect(result).toBe(input)
+    expect(() => transformCloudinaryImage(input, 400)).toThrow(
+      'transformCloudinaryImage: unrecognized Cloudinary URL variant: https://res.cloudinary.com/demo/image.jpg',
+    )
   })
 })

--- a/io/cloudinary/transformCloudinaryImage.ts
+++ b/io/cloudinary/transformCloudinaryImage.ts
@@ -16,6 +16,8 @@ export default function transformCloudinaryImage(url: string, width: number): st
     if (url.includes('youtube/')) {
       return url.replace('youtube/', `youtube/w_${width},f_auto,q_auto/`)
     }
+
+    throw new Error(`transformCloudinaryImage: unrecognized Cloudinary URL variant: ${url}`)
   }
 
   return url


### PR DESCRIPTION
## Summary

- After the three known path-segment branches (`upload/`, `fetch/`, `youtube/`), adds a `throw new Error(...)` when a Cloudinary URL matches none of the recognized variants.
- Updates the existing test case that previously expected the URL to be returned unchanged to instead expect the new error to be thrown.

## Test plan

- [ ] `transformCloudinaryImage` throws for a Cloudinary URL with an unrecognized path segment
- [ ] All 51 test files continue to pass

Closes #22

https://claude.ai/code/session_01LWPHUTNZkL6Ww9RungK9Hg

---
_Generated by [Claude Code](https://claude.ai/code/session_01LWPHUTNZkL6Ww9RungK9Hg)_