### PR TITLE
Assert exactly one result before accessing response.results[0] in getPost

### DIFF
--- a/io/notion/getPost.ts
+++ b/io/notion/getPost.ts
@@ -7,6 +7,7 @@ import { PostPageMetadataSchema } from './schemas/page'
 import { logValidationError } from '@/utils/logging/zod'
 import { env } from '@/io/env/env'
 import { Ok, Err, toErr, type Result } from '@/utils/errors/result'
+import { invariant } from '@/utils/errors/invariant'
 import { withRetry } from '@/io/utils/retry'
 
 type Options = {
@@ -129,6 +130,11 @@ export default async function getPost({
     if (response.results.length > 1) {
       throw Error(`Multiple posts found for slug: ${slug}\n${JSON.stringify(response.results)}`)
     }
+
+    invariant(
+      response.results.length === 1,
+      `Expected exactly one result for slug "${slug}", got ${response.results.length}`,
+    )
 
     // Transform and validate external data at boundary
     let post = transformNotionPageToPost(response.results[0])

--- a/io/notion/getPost.ts
+++ b/io/notion/getPost.ts
@@ -133,7 +133,7 @@ export default async function getPost({
 
     invariant(
       response.results.length === 1,
-      `Expected exactly one result for slug "${slug}", got ${response.results.length}`,
+      `Post query for slug "${slug}" must return exactly one result, not ${response.results.length}`,
     )
 
     // Transform and validate external data at boundary


### PR DESCRIPTION
## Summary

- Adds `invariant(response.results.length === 1, ...)` after the existing `results.length > 1` throw in `getPost`, so that accessing `results[0]` is guarded and any unexpected state (e.g. length 0 slipping past the earlier early-return) fails loudly.
- No test changes needed — the invariant is a defensive guard for a branch that existing logic already prevents.

## Test plan

- [ ] All 51 test files continue to pass
- [ ] TypeScript and lint checks pass

Closes #23

https://claude.ai/code/session_01LWPHUTNZkL6Ww9RungK9Hg

---
_Generated by [Claude Code](https://claude.ai/code/session_01LWPHUTNZkL6Ww9RungK9Hg)_