### PR TITLE
Assert publicId is non-empty in generateResponsiveImageUrls

### DIFF
--- a/io/cloudinary/fetchCloudinaryImageMetadata.test.ts
+++ b/io/cloudinary/fetchCloudinaryImageMetadata.test.ts
@@ -540,6 +540,13 @@ describe('fetchCloudinaryImageMetadata', () => {
 })
 
 describe('generateResponsiveImageUrls', () => {
+  it('throws when publicId is empty', () => {
+    const mockClient = createMockCloudinaryClient()
+    expect(() => generateResponsiveImageUrls('', mockClient)).toThrow(
+      'generateResponsiveImageUrls: publicId must not be empty',
+    )
+  })
+
   it('generates src URL with width 1440', () => {
     const mockClient = createMockCloudinaryClient()
     const result = generateResponsiveImageUrls('sample/image', mockClient)

--- a/io/cloudinary/fetchCloudinaryImageMetadata.test.ts
+++ b/io/cloudinary/fetchCloudinaryImageMetadata.test.ts
@@ -547,6 +547,13 @@ describe('generateResponsiveImageUrls', () => {
     )
   })
 
+  it('throws when publicId is whitespace only', () => {
+    const mockClient = createMockCloudinaryClient()
+    expect(() => generateResponsiveImageUrls('   ', mockClient)).toThrow(
+      'generateResponsiveImageUrls: publicId must not be empty',
+    )
+  })
+
   it('generates src URL with width 1440', () => {
     const mockClient = createMockCloudinaryClient()
     const result = generateResponsiveImageUrls('sample/image', mockClient)

--- a/io/cloudinary/fetchCloudinaryImageMetadata.ts
+++ b/io/cloudinary/fetchCloudinaryImageMetadata.ts
@@ -85,7 +85,7 @@ export function generateResponsiveImageUrls(
   cloudinaryClient: CloudinaryClient,
   effect?: ImageEffect,
 ): { src: string; srcSet: string; sizes: string } {
-  invariant(publicId.length > 0, 'generateResponsiveImageUrls: publicId must not be empty')
+  invariant(publicId.trim().length > 0, 'generateResponsiveImageUrls: publicId must not be empty')
 
   const widths = [
     350, // image layout width on phone at 1x DPR

--- a/io/cloudinary/fetchCloudinaryImageMetadata.ts
+++ b/io/cloudinary/fetchCloudinaryImageMetadata.ts
@@ -4,6 +4,7 @@ import { getErrorDetails } from '@/utils/logging/logging'
 import { formatValidationError } from '@/utils/logging/zod'
 import parsePublicIdFromCloudinaryUrl from './parsePublicIdFromCloudinaryUrl'
 import { Ok, toErr, type Result } from '@/utils/errors/result'
+import { invariant } from '@/utils/errors/invariant'
 import { z } from 'zod'
 import { ImageEffect } from 'cloudinary'
 import { withRetry } from '@/io/utils/retry'
@@ -84,6 +85,8 @@ export function generateResponsiveImageUrls(
   cloudinaryClient: CloudinaryClient,
   effect?: ImageEffect,
 ): { src: string; srcSet: string; sizes: string } {
+  invariant(publicId.length > 0, 'generateResponsiveImageUrls: publicId must not be empty')
+
   const widths = [
     350, // image layout width on phone at 1x DPR
     700, // image layout width on phone at 2x DPR


### PR DESCRIPTION
## Summary

- Adds `invariant(publicId.length > 0, 'generateResponsiveImageUrls: publicId must not be empty')` at the start of `generateResponsiveImageUrls` so an empty string fails loudly instead of silently producing malformed Cloudinary URLs.
- Adds a test case verifying the invariant throws for an empty `publicId`.

## Test plan

- [ ] `generateResponsiveImageUrls` throws when called with an empty `publicId`
- [ ] All 51 test files continue to pass (787 total tests, +1 new)

Closes #24

https://claude.ai/code/session_01LWPHUTNZkL6Ww9RungK9Hg

---
_Generated by [Claude Code](https://claude.ai/code/session_01LWPHUTNZkL6Ww9RungK9Hg)_