### PR TITLE
fix: correct test line count in README from 72k to ~12k

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@ My personal site where I write about what I'm learning and building 📝. It's a
 - **💾 Development caching** - First fetch hits real APIs, then results are cached locally by namespace. Zero network calls on page refresh during development
 - **🖼️ Responsive images** - Cloudinary integration generates srcsets with 9 sizes, automatic format/quality optimization, and enforced alt text
 - **🔒 Environment validation** - Zod validates all env vars at startup with helpful error messages instead of runtime undefined errors
-- **🧪 Comprehensive tests** - 72k lines of tests covering data flow integration, component behavior via Testing Library, and reusable property factories for test data
+- **🧪 Comprehensive tests** - ~12k lines of tests covering data flow integration, component behavior via Testing Library, and reusable property factories for test data
 
 **Tech:** TypeScript + Zod, Tailwind CSS 4, Vitest + Testing Library, GitHub Actions, Cloudflare Pages


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- The README claimed "72k lines of tests" but the actual count is 12,300 lines (a ~6x overcount)
- Updated line 16 of README.md to read "~12k lines of tests" to accurately reflect `find . -name "*.test.ts" -o -name "*.test.tsx" | xargs wc -l`

## Test plan

- [ ] Run `find . -name "*.test.ts" -o -name "*.test.tsx" | xargs wc -l` in the repo root — confirm `total` is ~12,300
- [ ] Open `README.md` line 16 — confirm the stated count matches (~12k)

Closes #30

## Related Links

- https://claude.ai/code/session_01JXbwWw7vxy9GW3wSh9Swi3
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JXbwWw7vxy9GW3wSh9Swi3)_