### PR TITLE
Fix wrong variable name and path in README.invariant.md "Documenting Complete Mapping" example

### DIFF
--- a/utils/errors/README.invariant.md
+++ b/utils/errors/README.invariant.md
@@ -196,8 +196,8 @@ invariant(metadata.width > 0 && metadata.height > 0, 'Image dimensions must be p
 ### Good: Documenting Complete Mapping
 
 ```typescript
-// ui/emoji.tsx
-const ariaLabel = emojiLabels[symbol]
+// ui/elements/emoji.tsx
+const ariaLabel = emojiLabel[symbol]
 invariant(ariaLabel, 'Emoji must have aria-label', { symbol })
 // Documents that our emoji map should cover all symbols
 ```


### PR DESCRIPTION
## What

- Corrects `emojiLabels[symbol]` to `emojiLabel[symbol]` in the "Documenting Complete Mapping" code block — the real variable is singular, no trailing `s`
- Corrects the path comment from `ui/emoji.tsx` to `ui/elements/emoji.tsx` to match the actual file location

## Why

- A reader copying the example snippet would get a reference error since `emojiLabels` does not exist in the codebase

## How to validate

- [ ] Open `utils/errors/README.invariant.md` and read the "Documenting Complete Mapping" block — expect `emojiLabel[symbol]` (singular) and path comment `// ui/elements/emoji.tsx`
- [ ] Open `ui/elements/emoji.tsx` — expect `const emojiLabel` on line 3 and `emojiLabel[symbol]` on line 30, matching the example

Closes #31

## Related links

- https://github.com/ooloth/michaeluloth.com/issues/31
- https://claude.ai/code/session_01Ajyob6XtCXqtQ87VKqXQrL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ajyob6XtCXqtQ87VKqXQrL)_