### PR TITLE
Fix wrong variable name and API in README.invariant.md "Documenting impossible states" example

### DIFF
--- a/utils/errors/README.invariant.md
+++ b/utils/errors/README.invariant.md
@@ -33,7 +33,7 @@ Use `invariant()` to document **impossible conditions** that should never occur 
 3. **Documenting impossible states**
 
    ```typescript
-   const ariaLabel = emojiMap.get(symbol)
+   const ariaLabel = emojiLabel[symbol]
    invariant(ariaLabel, 'Emoji must have aria-label', { symbol })
    // Documents that our emoji map should be complete
    ```


### PR DESCRIPTION
## What

- Corrects `emojiMap.get(symbol)` to `emojiLabel[symbol]` in the "Documenting impossible states" code block — the real code uses plain object bracket access on `emojiLabel`, not a Map API call on a nonexistent variable

## Why

- A reader copying this snippet would get a reference error: `emojiMap` does not exist in the codebase and `emojiLabel` is a plain object, not a Map

## How to validate

- [ ] Open `utils/errors/README.invariant.md` and find the "Documenting impossible states" block — expect `const ariaLabel = emojiLabel[symbol]` (plain object access, correct variable name)
- [ ] Open `ui/elements/emoji.tsx` line 30 — expect the same expression `emojiLabel[symbol]`, confirming the example matches the real code

Closes #29

## Related links

- https://github.com/ooloth/michaeluloth.com/issues/29
- https://claude.ai/code/session_01Ajyob6XtCXqtQ87VKqXQrL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ajyob6XtCXqtQ87VKqXQrL)_