### PR TITLE
Fix stale codebase example in README.invariant.md

### DIFF
--- a/utils/errors/README.invariant.md
+++ b/utils/errors/README.invariant.md
@@ -181,16 +181,12 @@ function getPost(slug: string) {
 
 ## Examples from Codebase
 
-### Good: Post-Validation Assertion
+### Good: Pre-Condition Guard
 
 ```typescript
-// lib/cloudinary/fetchCloudinaryImageMetadata.ts
-// Zod has already validated width/height are numbers
-invariant(metadata.width > 0 && metadata.height > 0, 'Image dimensions must be positive', {
-  width: metadata.width,
-  height: metadata.height,
-  publicId,
-})
+// io/cloudinary/fetchCloudinaryImageMetadata.ts
+// publicId has already been parsed from a validated Cloudinary URL
+invariant(publicId.trim().length > 0, 'generateResponsiveImageUrls: publicId must not be empty')
 ```
 
 ### Good: Documenting Complete Mapping
@@ -205,7 +201,7 @@ invariant(ariaLabel, 'Emoji must have aria-label', { symbol })
 ### Bad: Checking Function That Throws
 
 ```typescript
-// lib/cloudinary/fetchCloudinaryImageMetadata.ts (old code)
+// io/cloudinary/fetchCloudinaryImageMetadata.ts (old code, before this pattern was removed)
 const publicId = parsePublicIdFromCloudinaryUrl(url)
 invariant(publicId, 'Parser must find publicId')
 // BAD: parsePublicIdFromCloudinaryUrl throws if it can't parse


### PR DESCRIPTION
## ✅ What

- Replaces the stale "Good: Post-Validation Assertion" example (which cited a deleted dimensions invariant at an old file path) with the actual invariant present at `io/cloudinary/fetchCloudinaryImageMetadata.ts`
- Updates the section heading to "Pre-Condition Guard" to accurately describe the replacement
- Fixes the old `lib/cloudinary/` path in the "Bad" example to `io/cloudinary/`

## 🤔 Why

- A reader following the cited file path would find neither the path nor the invariant call, making the example misleading

## 👩‍🔬 How to validate

- [ ] Open `utils/errors/README.invariant.md` and read the "Good: Pre-Condition Guard" example — expect the file path to be `io/cloudinary/fetchCloudinaryImageMetadata.ts`
- [ ] Open `io/cloudinary/fetchCloudinaryImageMetadata.ts` and search for `publicId.trim().length > 0` — expect to find that exact invariant call in `generateResponsiveImageUrls`

## 🔖 Related links

- https://github.com/ooloth/michaeluloth.com/issues/28
- https://claude.ai/code/session_01NX6Sqy1LRifn2ZbMjm4gcM

Closes #28

---
_Generated by [Claude Code](https://claude.ai/code/session_01NX6Sqy1LRifn2ZbMjm4gcM)_